### PR TITLE
Arrow Refactor

### DIFF
--- a/Tex/Chapters/Chapter_1.tex
+++ b/Tex/Chapters/Chapter_1.tex
@@ -537,12 +537,13 @@ Mit dem ersten Cantorschen Diagonalverfahren kann man die rationalen Zahlen abz�
 %connection through points
 \draw (1,1)--(1,2)--(2,1)--(3,1)--(2,2)--(1,3)--(1,4)--(4,1)--(5,1)--(2,4)--(3,4)--(6,1);
 
-% Psis
+% Psisgit 
 
 \end{tikzpicture}
 \end{center}
-\section{Dedekind Schubladen Prinzip}\todo{Is this supposed to be a new chapter?? page 19}
-Sei $f:A\rightarrow B$ eine beliebige Abbildung zwischen endliche Mengen. Falls $\left| B\right| < \left| A \right|$ dann ist $f$ nicht injektiv, d.h. es gibt $b\in B$ und $a_1,a_2\in A$ mit
+\section{Dedekind Schubladen Prinzip}
+Sei $f:A\rightarrow B$ eine beliebige Abbildung zwischen endlichen Mengen. Falls ${\left| B\right| < \left| A \right|}$ % the {} prevent undesired breaking of formula
+dann ist $f$ nicht injektiv, d.h. es gibt $b\in B$ und $a_1,a_2\in A$ mit
 \begin{enumerate}[i)]
 \item $a_1\not=a_2$
 \item $f(a_1)=f(a_2)=b$
@@ -586,30 +587,41 @@ Sei $f:A\rightarrow B$ eine beliebige Abbildung zwischen endliche Mengen. Falls 
 \end{center}
 \centerline{$3=\left| B\right| < 5 = \left| A \right|$}
 
-Mit Abbildungen kann man ``operieren''. Die wichstige Operation ist die Verkettung (oder komposition) zweier Abbildungen. 
+Mit Abbildungen kann man ``operieren''. Die wichtigste Operation ist dabei die Verkettung (oder Komposition) zweier Abbildungen. 
 
 \begin{definition}
 \noindent Abbildungen $f:X\rightarrow $, $g:Y\rightarrow Z$ kann man miteinander ausführen. Dies ergibt eine neue Abbildung \[X\mathop  \to \limits^f Y\mathop  \to \limits^g Z\] \[F:=g\circ f:X\rightarrow Z, x\rightarrow g\left( f(x)\right)   \]
+\[\text{Man sagt}
+\begin{cases}
+g \text{ nach } f \\
+g \text{ komponiert mit } f \\
+g \circ f
+\end{cases}\]
 \end{definition}
-Zwei Funktionen $f$ und $g$ können verkettet werden wenn der Wertebereich der ersten Funktion mit dem Definitionsbereich der zweiten Funktion übereinstimmt. 
-
-\[\text{Man Sagt}\left\{ {\begin{array}{*{20}{c}}
-{g\text{ nach }f\text{ oder }}\\
-{g\text{ komponiert mit }f}\\
-{g\circ f}
-\end{array}} \right.\]
-
+Zwei Funktionen $f$ und $g$ können verkettet werden, falls der Wertebereich der ersten Funktion mit dem Definitionsbereich der zweiten Funktion übereinstimmt.
 \underline{Zu Beachten:}
 In dieser Notation steht die zuerst angewandte Abbildung rechts; das heisst bei $g\circ f$ wird zuerst die Funktion $f$ angewandt und dann die Funktion $g$. 
 \begin{itemize}
-\item Die Identische Abbildung verhölt sich bei der Komposition \todo{?neu?, page 19.2 top}, für eine Funktion \[f:X\rightarrow Y \text{ gilt also}\]
-\[f\circ id_X=f=id_Y \circ Y\] wobei \[id_X:\Romanbar{X}\rightarrow\Romanbar{X}\]\[x\rightarrow x\] \[id_Y :Y\rightarrow Y\]\[y\rightarrow y\]
+\item Die Identische Abbildung verhält sich bei der Komposition neutral, für eine Funktion \[f:X\rightarrow Y \text{ gilt also}\]
+\[f\circ id_X=f=id_Y \circ Y\] wobei
+\begin{align*}
+id_X:\Romanbar{X}&\rightarrow\Romanbar{X} \\
+x&\rightarrow x \\
+id_Y :Y&\rightarrow Y \\ 
+y&\rightarrow y
+\end{align*}
 
-\item Die Komposition von Funktionen ist associativ, d.h. für Funktionen $f,g,h$ gilt \[\left( h\circ g\right)\circ f=h\circ \left( g\circ f\right)\]
+\item Die Komposition von Funktionen ist assoziativ, d.h. für Funktionen $f,g,h$ gilt \[\left( h\circ g\right)\circ f=h\circ \left( g\circ f\right)\]
 \item Aber die Komposition von Funktionen ist im Allgemeinen nicht kommutativ! \[f\circ g\not= g\circ f\]
 Zum Beispiel:
-\[f:\mathbb{R}\rightarrow\mathbb{R}\]\[x\rightarrow x^2\]\[g:\mathbb{R}\rightarrow\mathbb{R}\]\[x\rightarrow x+1\]
-\[f\circ g=f\left( g(x)\right)=f(x+1)=(x+1)^2=x^2+2x+1\]\[g\circ f=g\left( f(x)\right)=g(x^2)=x^2+1\]
+\begin{align*}
+f:\mathbb{R} &\rightarrow\mathbb{R} \\
+x &\rightarrow x^2 \\
+g:\mathbb{R}&\rightarrow\mathbb{R} \\
+x &\rightarrow x+1
+\end{align*}
+\[f\circ g=f\left( g(x)\right)=f(x+1)=(x+1)^2=x^2+2x+1 \]
+\[g\circ f=g\left( f(x)\right)=g(x^2)=x^2+1\]
 \end{itemize}
 
 \section{Die Inverse Abbildung (Umkehrfunktion)}

--- a/Tex/Chapters/Chapter_1.tex
+++ b/Tex/Chapters/Chapter_1.tex
@@ -19,27 +19,27 @@ Seien $A,B$ Aussagen
 \end{itemize}
 \subsubsection*{Folgerung (eine wahre Implikation)}
 \begin{itemize}
-\item Aus $A$ folgt $B$ wird mit $\Rightarrow$ bezeichnet
+\item Aus $A$ folgt $B$ wird mit $\to$ bezeichnet
 \item Wenn $A$, dann auch $B$
 \item Die Negation der Aussage $A$ wird mit $\lnot A$ bezeichnet
 \item $A$ ist equivalent zu $B$ wird mit $A\Leftrightarrow B$ bezeichnet
-\item $\left(A\Rightarrow B\right)\land \left( B\Rightarrow A\right)$ $A$ wahr genau dann, wenn $B$ wahr ist.
+\item $\left(A\to B\right)\land \left( B\to A\right)$ $A$ wahr genau dann, wenn $B$ wahr ist.
 \end{itemize}
 
 \subsubsection*{Bemerkung}
-Die Folgerung ist transitiv. Wenn wir wissen, dass $A\Rightarrow B$ und $B\Rightarrow C$, dann wissen wir dass $A\Rightarrow C$.
+Die Folgerung ist transitiv. Wenn wir wissen, dass $A\to B$ und $B\to C$, dann wissen wir dass $A\to C$.
 
 
 \subsection*{Prinzip des Mathematischen Beweises}
-Wir können ber eine Kette von Folgerungen \[A\Rightarrow B \Rightarrow C \dots \Rightarrow S\]
+Wir können ber eine Kette von Folgerungen \[A\to B \to C \dots \to S\]
 einen mathematischen ``Satz'' $S$ aus einen Annahme $A$ herleiten. (Ein Beweis ist eine Folge von Implikationen von Aussagen). 
 \subsubsection*{Kontraposition (Umkehrschluss)}
 
-$A\Rightarrow B$ ist gleichbedeutend mit $\lnot B\Rightarrow\lnot A$.\\
-Falls $A\Rightarrow B$, so kann $A$ nicht wahr sein wenn $B$ falsch ist (weil $A$ wahr wäre, würde $B$ auch wahr sein).
+$A\to B$ ist gleichbedeutend mit $\lnot B\to\lnot A$.\\
+Falls $A\to B$, so kann $A$ nicht wahr sein wenn $B$ falsch ist (weil $A$ wahr wäre, würde $B$ auch wahr sein).
 
 \section{Prinzip des Indirekten Beweises}
-Zum Beweis der Aussage $A\Rightarrow B$ genügt es die Aussage $\lnot B\Rightarrow\lnot A$ zu zeigen, oder: die Annahme $A\land\lnot B$ zum Wiederspruch zu führen.
+Zum Beweis der Aussage $A\to B$ genügt es die Aussage $\lnot B\to\lnot A$ zu zeigen, oder: die Annahme $A\land\lnot B$ zum Wiederspruch zu führen.
 
 \subsection*{Indirekter Beweis}
 Man fügt $\lnot B$ als Annahme hinzu und kommt nach einer Kette von erlaubten Schlüssen zu einer falschen Aussage.\\
@@ -79,7 +79,7 @@ Falls zugleich $A\subset B$ und $B\subset A$ gilt, so sind $A$ und $B$ gleich un
 Wir werden die folgenden zwei Beweismethoden häufig benutzen.
 
  \subsection*{1. Prinzip des Indirekten Beweises}
-Zum Beweis der Aussage $A\Rightarrow B$ genügt es die Aussage $\lnot B\Rightarrow\lnot A$ zu zeigen, oder, die Annahme $A\land\lnot B$ zum Wiederspruch zu führen.
+Zum Beweis der Aussage $A\to B$ genügt es die Aussage $\lnot B\to\lnot A$ zu zeigen, oder, die Annahme $A\land\lnot B$ zum Wiederspruch zu führen.
 \subsection*{2. Prinzip der Vollständigen Induktion}
 Sei für jedes $n\in\mathbb{N}$ eine Behauptung $A(n)$ gegeben. Soll die Behauptung für alle natürlichen Zahlen $n\in\mathbb{N}$ bewiessen werden, so genügen dazu zwei Beweisschritte:
 \begin{enumerate}[i)]
@@ -94,7 +94,7 @@ Soll die Gültigkeit von $A(n)$ für alle $n\geq m$ bewiesen werden so genügen 
 \end{enumerate}
 Das Prinzip der Vollständigen Induktion ist genau wie ein Dominoeffekt.\\
 
-Sie stellen alle Dominosteinen eine nach der andere. Falls der erste Dominostein fällt ($A(1)$ wahr) und falls wir die Dominosteine genug nah nebeneinander gestellt haben, so dass ein fallender Dominostein den nächsten trifft ($A(k)\Rightarrow A(k+1)$) dann wissen wir, dass alle Dominosteine fallen. 
+Sie stellen alle Dominosteinen eine nach der andere. Falls der erste Dominostein fällt ($A(1)$ wahr) und falls wir die Dominosteine genug nah nebeneinander gestellt haben, so dass ein fallender Dominostein den nächsten trifft ($A(k)\to A(k+1)$) dann wissen wir, dass alle Dominosteine fallen. 
 
 \subsubsection*{Beispiel 1.3 (Induktion)}
 \begin{enumerate}
@@ -139,20 +139,20 @@ $b$ ist Vielfaches von $a$ & ~\\
 \begin{itemize}
 \item Gilt $a\mid b$ und $b\mid c$, so folgt $a\mid c$
 \item Für $k\in\mathbb{Z}\backslash\{0\}$ gilt: $a\mid b\Longleftrightarrow ka\mid kc$ 
-\item $a\mid b$ und $c\mid d\Rightarrow ac\mid bd$
-\item $a\mid b$ und $a\mid c\Rightarrow a\mid kb+lc,\text{    für alle }l,k\in\mathbb{Z}$
+\item $a\mid b$ und $c\mid d\to ac\mid bd$
+\item $a\mid b$ und $a\mid c\to a\mid kb+lc,\text{    für alle }l,k\in\mathbb{Z}$
 \end{itemize}
 
 \begin{enumerate}
 \item $k=\left( p_1 p_2\dots p_i \dots p_m \right)+1$\\
 Es gibt eine Primzahl $p_i$ dass $k$ teilt. $p_i\mid k$ mittels Satz 1.4.
 \item Sei $b=p_1 p_2\dots p_i \dots p_m=$ produkt aller Primzahlen. Sei $a=p_i$, $n=p_1 p_2 p_{i-1} p_{i+1} \dots p_m$. Dann $b=an$. Dass heisst $a$ ist Teiler von $b$, d.h. $p_i\mid\left(p_1\dots p_m\right)$
-\item $p_i\mid k$ und $p_i\mid \left(p_1\dots p_m\right) \Rightarrow p_i \mid k-\left(p_1\dots p_m\right)=1$.\\
+\item $p_i\mid k$ und $p_i\mid \left(p_1\dots p_m\right) \to p_i \mid k-\left(p_1\dots p_m\right)=1$.\\
 So erhalten wir einen Wiederspruch
 \end{enumerate}
 
 \subsubsection*{Bemerkung}
-Letztes mal haben wir gesagt, dass jedes Element von $A$ ist auch Element von $B$ ($\forall x,x\in A\Rightarrow x\in B$) mit $A\subset B$ bezeichnet wird. Wir sagen auch $A$ ist in $B$ enthalten oder $A$ ist Teilmenge von $B$. Falls $A\subset B$ und eine Element $b\in B$ gibt mit $b\not\in A$ sagen wir $A$ ist eine ``eigentliche Teilmenge'' von $B$. Manchmal schreiben wir $A\mathop  \subset \limits_{\not  = } B$ in diesem Fall. \\
+Letztes mal haben wir gesagt, dass jedes Element von $A$ ist auch Element von $B$ ($\forall x,x\in A\to x\in B$) mit $A\subset B$ bezeichnet wird. Wir sagen auch $A$ ist in $B$ enthalten oder $A$ ist Teilmenge von $B$. Falls $A\subset B$ und eine Element $b\in B$ gibt mit $b\not\in A$ sagen wir $A$ ist eine ``eigentliche Teilmenge'' von $B$. Manchmal schreiben wir $A\mathop  \subset \limits_{\not  = } B$ in diesem Fall. \\
 
 Es gibt viele Bücher mit der folgenden Notation: jedes Element von $A$ ist ein Element von $B$ wird mit $A\subseteq B$ bezeichnet. Und wenn $A\subseteq B$ und $A\not =B$ dann benutzen sie $A\subset B$ statt $A\mathop  \subset \limits_{\not  = } B$. $A=B$ falls $x\in A\Leftrightarrow x\in B$. 
 
@@ -161,13 +161,13 @@ $A=B \Leftrightarrow A\subset B$ und $B\subset A$
 \subsubsection*{Beweis}
 Annahme: $A=B$. Falls $x\in A$, dann mittels $A=B$, $x\in B$ gilt, damit gilt $A\subset B$ und falls $x\in B$, dann $x\in A$ gilt (mittels $A=B$) damit gilt $B\subset A$.\\
 
-Wir haben bewiesen dass $A=B \Rightarrow A\subset B \text{ und } B\subset A$. Zunächst nehmen wir an dass $A\subset B$ und $B\subset A$. Wir möchten zeigen dass $A=B$. \\
+Wir haben bewiesen dass $A=B \to A\subset B \text{ und } B\subset A$. Zunächst nehmen wir an dass $A\subset B$ und $B\subset A$. Wir möchten zeigen dass $A=B$. \\
 
-Sei $x\in A$, mittels $A\subset B$, haben wir $x\in B$ somit $x\in A \Rightarrow x\in B$. (\textasteriskcentered)\\
+Sei $x\in A$, mittels $A\subset B$, haben wir $x\in B$ somit $x\in A \to x\in B$. (\textasteriskcentered)\\
 
-Sei $x\in B$, mittels $B\subset A$, haben wir $x\in A$ somit $x\in B \Rightarrow x\in A$. (\textasteriskcentered\textasteriskcentered)\\
+Sei $x\in B$, mittels $B\subset A$, haben wir $x\in A$ somit $x\in B \to x\in A$. (\textasteriskcentered\textasteriskcentered)\\
 
-(\textasteriskcentered) und (\textasteriskcentered\textasteriskcentered) $\Rightarrow A=B$ per Definition. 
+(\textasteriskcentered) und (\textasteriskcentered\textasteriskcentered) $\to A=B$ per Definition. 
 
 \section{Mengeoperationen}
 Zunächst erinnern wir kurz an die Definitionen der elementaren Operationen auf Mengen. \\
@@ -342,7 +342,7 @@ und
 Seien $X,Y$ Mengen. 
 
 \begin{definition}{1.9}
-Eine Funktion oder Abbildung $f:X\rightarrow Y$ der Menge $X$ in die Menge $Y$ ist eine Vorschrift (ein Gesetz) die (das) jedem Element $x\in A$ genau ein Element $y=f(x)\in Y$ zuordnet. \\
+Eine Funktion oder Abbildung $f:X\to Y$ der Menge $X$ in die Menge $Y$ ist eine Vorschrift (ein Gesetz) die (das) jedem Element $x\in A$ genau ein Element $y=f(x)\in Y$ zuordnet. \\
 
 Es gibt verschiedene wichtige Objekte die in Zusammenhang mit einem Abbildung auftreten 
 \begin{align*}X &= \text{ \emph{Definitionsbereich} oder \emph{Definitionsmenge} (domain)} \\
@@ -355,7 +355,7 @@ Der \emph{Graph} einer Funktion $f$ ist die Menge aller Paare $(x, f(x))$ wobei 
 
 \subsubsection*{Beispiel 1.10}
 \begin{enumerate}
-\item (Identität) Für jede Menge $\Romanbar{X}$, ist $id_X : \Romanbar{X} \rightarrow\Romanbar{X}$ definiert durch $id_{\Romanbar{X}}(x)=x, \forall x\in X$ 
+\item (Identität) Für jede Menge $\Romanbar{X}$, ist $id_X : \Romanbar{X} \to\Romanbar{X}$ definiert durch $id_{\Romanbar{X}}(x)=x, \forall x\in X$ 
 
 \begin{center}
 \begin{tikzpicture}[scale=0.5]
@@ -421,15 +421,15 @@ Der \emph{Graph} einer Funktion $f$ ist die Menge aller Paare $(x, f(x))$ wobei 
 
 \item Seien $X,Y$ Mengen. Dann sind \\
 \begin{tabular}{r  l c r l c }
-$pr_x:$ & $X\times Y\rightarrow X $& ~ & $pr_y$: & $X\times Y\rightarrow Y$ \\
-~& $(x,y)\rightarrow x$ & ~& ~& $(x,y)\rightarrow y$ \\
+$pr_x:$ & $X\times Y\to X $& ~ & $pr_y$: & $X\times Y\to Y$ \\
+~& $(x,y)\mapsto x$ & ~& ~& $(x,y)\mapsto y$ \\
 \end{tabular}\\
 die Projektionen auf den ersten bzw. zweiten Faktoren. 
-\item Sinus \begin{align*} f:\mathbb{R}&\rightarrow\lbrack -1,1\rbrack \\ x &\rightarrow \sin x \end{align*}
-\item \begin{align*}f:\mathbb{R}&\rightarrow\mathbb{R} \\ x&\rightarrow x^2+x\end{align*}
+\item Sinus \begin{align*} f:\mathbb{R}&\to\lbrack -1,1\rbrack \\ x &\mapsto \sin x \end{align*}
+\item \begin{align*}f:\mathbb{R}&\to\mathbb{R} \\ x&\mapsto x^2+x\end{align*}
 \end{enumerate}
 \begin{definition}{1.11}
-Sei $f:X\rightarrow Y$ eine Abbildung
+Sei $f:X\to Y$ eine Abbildung
 \begin{enumerate}
 \item $f$ heisst injektiv falls auf $f(x_1)=f(x_2)$ stets $x_1=x_2$ folgt, falls jeder $y<\in Y$ höchstens ein Urbild hat.
 \item $f$ heisst surjektiv falls für jedes $y\in Y$ ein $x\in X$ gibt mit $f(x)=y$ \[\forall y\in Y, \exists x\in X:f(x)=y\]wenn jedes Element $y\in Y$ mindestens ein Urbild hat. 
@@ -440,37 +440,37 @@ Sei $f:X\rightarrow Y$ eine Abbildung
 \begin{multicols}{2}
 [\subsubsection*{Beispiel 1.12}]
 \begin{enumerate}
-\item $id_{X}:X\rightarrow X$ bijektiv.
+\item $id_{X}:X\to X$ bijektiv.
 \item Eine konstante Abbildung \\
-	$f:\Romanbar{X}\rightarrow X, x\rightarrow c$ ist 
+	$f:\Romanbar{X}\to X, x\mapsto c$ ist 
 \begin{itemize}
 \item injektiv $\Leftrightarrow \Romanbar{X}=\{ c\}$
 \item surjektiv $\Leftrightarrow X=\{ c\}$
 \end{itemize}
 \item Die Projektionen 
 \begin{itemize}
-\item $pr_x : X\times Y\rightarrow X$ 
-\item $pr_y : X\times Y\rightarrow Y$ 
+\item $pr_x : X\times Y\to X$ 
+\item $pr_y : X\times Y\to Y$ 
 \end{itemize}
 sind stets surjektiv.
-\item $f:\mathbb{R}\rightarrow\lbrack -1,1\rbrack$ \\
-$x\rightarrow \sin x$\\
+\item $f:\mathbb{R}\to\lbrack -1,1\rbrack$ \\
+$x\mapsto \sin x$\\
 Surjektiv, nicht injektiv
 \columnbreak
-\item $f:\mathbb{R}\rightarrow\mathbb{R}$\\
-$x\rightarrow x^2$\\
+\item $f:\mathbb{R}\to\mathbb{R}$\\
+$x\mapsto x^2$\\
 Nicht surjektiv\\
 Nicht injektiv
 
-\item $f:\mathbb{N}\rightarrow\mathbb{N}$\\
-$n\rightarrow 2n$\\
+\item $f:\mathbb{N}\to\mathbb{N}$\\
+$n\mapsto 2n$\\
 ist injektiv. $f(\mathbb{N})$ ist die Menge aller geraden Zahlen
-\item Eine Menge $A$ hat $n$ Elemente falls es eine bijektive ${f:\{1,\dots,n\}\rightarrow A}$ gibt. Die Zahl $n$ wird dann die Kardinalität von $A$ genannt und mit $|A|$, gelegentlich auch mit $\#A$ bezeichnet.
+\item Eine Menge $A$ hat $n$ Elemente falls es eine bijektive ${f:\{1,\dots,n\}\to A}$ gibt. Die Zahl $n$ wird dann die Kardinalität von $A$ genannt und mit $|A|$, gelegentlich auch mit $\#A$ bezeichnet.
 \end{enumerate}
 \end{multicols}
 
 \begin{definition}{Kardinalität}
-Wir sagen zwei Mengen $X$ und $Y$ sind gleichmächtig falls eine bijektive Abbildung $f:X\rightarrow Y$ gibt.
+Wir sagen zwei Mengen $X$ und $Y$ sind gleichmächtig falls eine bijektive Abbildung $f:X\to Y$ gibt.
 \end{definition}
 
 Mit dem ersten Cantorschen Diagonalverfahren kann man die rationalen Zahlen abzählen, d.h.$ \mathbb{Q}$ und $\mathbb{N}$ sind gleichmächtig
@@ -542,7 +542,7 @@ Mit dem ersten Cantorschen Diagonalverfahren kann man die rationalen Zahlen abz�
 \end{tikzpicture}
 \end{center}
 \section{Dedekind Schubladen Prinzip}
-Sei $f:A\rightarrow B$ eine beliebige Abbildung zwischen endlichen Mengen. Falls ${\left| B\right| < \left| A \right|}$ % the {} prevent undesired breaking of formula
+Sei $f:A\to B$ eine beliebige Abbildung zwischen endlichen Mengen. Falls ${\left| B\right| < \left| A \right|}$ % the {} prevent undesired breaking of formula
 dann ist $f$ nicht injektiv, d.h. es gibt $b\in B$ und $a_1,a_2\in A$ mit
 \begin{enumerate}[i)]
 \item $a_1\not=a_2$
@@ -590,7 +590,7 @@ dann ist $f$ nicht injektiv, d.h. es gibt $b\in B$ und $a_1,a_2\in A$ mit
 Mit Abbildungen kann man ``operieren''. Die wichtigste Operation ist dabei die Verkettung (oder Komposition) zweier Abbildungen. 
 
 \begin{definition}
-\noindent Abbildungen $f:X\rightarrow $, $g:Y\rightarrow Z$ kann man miteinander ausführen. Dies ergibt eine neue Abbildung \[X\mathop  \to \limits^f Y\mathop  \to \limits^g Z\] \[F:=g\circ f:X\rightarrow Z, x\rightarrow g\left( f(x)\right)   \]
+\noindent Abbildungen $f:X\to $, $g:Y\to Z$ kann man miteinander ausführen. Dies ergibt eine neue Abbildung \[X\mathop  \to \limits^f Y\mathop  \to \limits^g Z\] \[F:=g\circ f:X\to Z, x\mapsto g\left( f(x)\right)   \]
 \[\text{Man sagt}
 \begin{cases}
 g \text{ nach } f \\
@@ -602,32 +602,32 @@ Zwei Funktionen $f$ und $g$ können verkettet werden, falls der Wertebereich der
 \underline{Zu Beachten:}
 In dieser Notation steht die zuerst angewandte Abbildung rechts; das heisst bei $g\circ f$ wird zuerst die Funktion $f$ angewandt und dann die Funktion $g$. 
 \begin{itemize}
-\item Die Identische Abbildung verhält sich bei der Komposition neutral, für eine Funktion \[f:X\rightarrow Y \text{ gilt also}\]
+\item Die Identische Abbildung verhält sich bei der Komposition neutral, für eine Funktion \[f:X\to Y \text{ gilt also}\]
 \[f\circ id_X=f=id_Y \circ Y\] wobei
 \begin{align*}
-id_X:\Romanbar{X}&\rightarrow\Romanbar{X} \\
-x&\rightarrow x \\
-id_Y :Y&\rightarrow Y \\ 
-y&\rightarrow y
+id_X:\Romanbar{X}&\to\Romanbar{X} \\
+x&\mapsto x \\
+id_Y :Y&\to Y \\ 
+y&\mapsto y
 \end{align*}
 
 \item Die Komposition von Funktionen ist assoziativ, d.h. für Funktionen $f,g,h$ gilt \[\left( h\circ g\right)\circ f=h\circ \left( g\circ f\right)\]
 \item Aber die Komposition von Funktionen ist im Allgemeinen nicht kommutativ! \[f\circ g\not= g\circ f\]
 Zum Beispiel:
 \begin{align*}
-f:\mathbb{R} &\rightarrow\mathbb{R} \\
-x &\rightarrow x^2 \\
-g:\mathbb{R}&\rightarrow\mathbb{R} \\
-x &\rightarrow x+1
+f:\mathbb{R} &\to\mathbb{R} \\
+x &\mapsto x^2 \\
+g:\mathbb{R}&\to\mathbb{R} \\
+x &\mapsto x+1
 \end{align*}
 \[f\circ g=f\left( g(x)\right)=f(x+1)=(x+1)^2=x^2+2x+1 \]
 \[g\circ f=g\left( f(x)\right)=g(x^2)=x^2+1\]
 \end{itemize}
 
 \section{Die Inverse Abbildung (Umkehrfunktion)}
-Sei $f:X\rightarrow Y$ eine bijektiven Funktion. \\
+Sei $f:X\to Y$ eine bijektiven Funktion. \\
 
-Die Inverse Funktion $g:Y\rightarrow X$, einer bijektiven Funktion $f:X\rightarrow Y$ ist die Funktion, die jedem Element $y$ der Zielmenge seien eindeutig bestimmtes Urbildelement zuweist. (bei bijektiven Funktionen hat die Urbildmenge jedes Element $y$ genau ein Element). \\
+Die Inverse Funktion $g:Y\to X$, einer bijektiven Funktion $f:X\to Y$ ist die Funktion, die jedem Element $y$ der Zielmenge seien eindeutig bestimmtes Urbildelement zuweist. (bei bijektiven Funktionen hat die Urbildmenge jedes Element $y$ genau ein Element). \\
 
  $g(y):=x$, eindeutig definierte $ x\in\Romanbar{X}$, mit $f(x)=y$. Dann ist definitionsgemäss $(g\circ f)(x)=x$, d.h. $g\circ f:id_{\Romanbar{X}}$. Die Eindeutig definierte Abbildung $g$ wird (auch) mit $f^{-1}$ bezeichnet und Inverse von $f$ genannt.\\
 
@@ -635,13 +635,13 @@ Für $f\circ f^{-1}:$ Sei $y\in Y$ und sei $x$ mit $f(x)=y$. Dann ist $\left( f\
 
 \subsubsection*{Beispiel}
 \begin{enumerate}
-\item \[f:\mathbb{R}\rightarrow\mathbb{R}\]\[x\rightarrow 2x+3\] bijektive\\
-Umkehrfunktion ist gegeben durch \[f^{-1}:\mathbb{R}\rightarrow\mathbb{R}\]\[x\rightarrow\frac{x-3}{2}\]
-\item Sei $\mathbb{R}^+=\lbrack 0,\infty\rbrack$ die Menge der nichtnegativen reelen Zahlen und \[f:\mathbb{R}^+\rightarrow\mathbb{R}^+\] mit \[x\rightarrow x^2\]
-Dann ist $f$ bijektive und die Umkehrfunktion \[f^{-1}:\mathbb{R}^+\rightarrow\mathbb{R}^+\] ist gegeben durch \[x\rightarrow\sqrt{x}\]
+\item \[f:\mathbb{R}\to\mathbb{R}\]\[x\mapsto 2x+3\] bijektive\\
+Umkehrfunktion ist gegeben durch \[f^{-1}:\mathbb{R}\to\mathbb{R}\]\[x\mapsto\frac{x-3}{2}\]
+\item Sei $\mathbb{R}^+=\lbrack 0,\infty\rbrack$ die Menge der nichtnegativen reelen Zahlen und \[f:\mathbb{R}^+\to\mathbb{R}^+\] mit \[x\mapsto x^2\]
+Dann ist $f$ bijektive und die Umkehrfunktion \[f^{-1}:\mathbb{R}^+\to\mathbb{R}^+\] ist gegeben durch \[x\mapsto\sqrt{x}\]
 \end{enumerate}
 
 \underline{Verallgemenerungen}
-Falls $f:X\rightarrow Y$ injektive ist, kann man die Umkehrabbildung \[f^{-1}:f\left(\Romanbar{X}\right)\rightarrow\Romanbar{X}\] definieren. Das heisst, die Funktion $f^{-1}$ erfüllt: wenn $f(x)=y$, dann $f^{-1}(y)=x$\\
+Falls $f:X\to Y$ injektive ist, kann man die Umkehrabbildung \[f^{-1}:f\left(\Romanbar{X}\right)\to\Romanbar{X}\] definieren. Das heisst, die Funktion $f^{-1}$ erfüllt: wenn $f(x)=y$, dann $f^{-1}(y)=x$\\
 
 \noindent Vorsicht: $f^{-1}\circ f=id_{\Romanbar{X}}$ aber $f\circ f^{-1}=id_{f\left(\Romanbar{X}\right)}$ und $f\circ f^{-1}=id_Y$ genau dann wenn $f(X)=Y$, d.h. $f$ bijektive ist.

--- a/Tex/Chapters/Chapter_1.tex
+++ b/Tex/Chapters/Chapter_1.tex
@@ -537,7 +537,7 @@ Mit dem ersten Cantorschen Diagonalverfahren kann man die rationalen Zahlen abz√
 %connection through points
 \draw (1,1)--(1,2)--(2,1)--(3,1)--(2,2)--(1,3)--(1,4)--(4,1)--(5,1)--(2,4)--(3,4)--(6,1);
 
-% Psisgit 
+% Psis
 
 \end{tikzpicture}
 \end{center}

--- a/Tex/Chapters/Chapter_2.tex
+++ b/Tex/Chapters/Chapter_2.tex
@@ -12,7 +12,7 @@ Viele gleichungen haben keine Lösung in $\mathbb{Q}$.
 \subsubsection*{Satz 2.1}
 Sei $p\in\mathbb{N}$ eine Primzahl. Dann hat $x^2=p$ keine Lösung in $\mathbb{Q}$
 \subsubsection*{Beweis}
-Zum Erinnerung zwei Natürlichen Zahlen $a$ und $b$ sind teilfrmd (oder relativ prim) wenn es keine Natürliche Zahl ausser der Eins gibt, die beiden Zahlen teilt. \[\left( (a,b)=1\right)\rightarrow\text{ grösste Gemeinsame Teiler}\]
+Zum Erinnerung zwei Natürlichen Zahlen $a$ und $b$ sind teilfrmd (oder relativ prim) wenn es keine Natürliche Zahl ausser der Eins gibt, die beiden Zahlen teilt. \[\left( (a,b)=1\right)\to\text{ grösste Gemeinsame Teiler}\]
 
 \subsubsection*{Indirekter Beweis}
 Wir nehmen an: es gibt $x=\frac{a}{b}\in \mathbb{Q}$ mit $x^2 =p$, wobei $a,b$ teilfremd und $\geq 1$ sind. Dann gilt \[a^2=pb^2\] woraus folgt, dass $p$ $a$ teilt also ist $a=pk$, $k\in\mathbb{N}$ und somit \[a^2=p^2k^2=pb^2\Rightarrow pk^2=b^2\] woraus folgt, dass $p$ $b$ teilt.
@@ -25,10 +25,10 @@ Die Menge $\mathbb{R}$ der Reelen Zahlen ist mit zwei Verknüpfungen ``$+$'' (Ad
 \item \textbf{$\left( \mathbb{R},+,\cdot\right)$ ist ein Koerper}\\
 Es gibt 2 Operationen (Zweistellige Verknüpfungen)
 \begin{itemize}
-\item $+:\mathbb{R}\times\mathbb{R}\rightarrow\mathbb{R}$\\
-$(a,b)\rightarrow a+b$
-\item $\times:\mathbb{R}\times\mathbb{R}\rightarrow\mathbb{R}$\\
-$(a,b)\rightarrow a\cdot b$
+\item $+:\mathbb{R}\times\mathbb{R}\to\mathbb{R}$\\
+$(a,b)\mapsto a+b$
+\item $\times:\mathbb{R}\times\mathbb{R}\to\mathbb{R}$\\
+$(a,b)\mapsto a\cdot b$
 \end{itemize}
 und 2 ausgezeichnete Element 0 und 1 in $\mathbb{R}$ die folgenden Eigenschaften haben:\\
 
@@ -50,15 +50,15 @@ Inverse Element  & M4) & $\forall x\in\mathbb{R}, x\not =0$  $ \exists y\in\math
 und Die Multiplikation ist verträglich it der Addition im Sinne des Distributivitäts-Gesetz (D)\[\forall x,y,z\in\mathbb{R}:x(y+z)=xy+xz\]
 
 \begin{itemize}
-\item $( \mathbb{R},+)$ mit A1$\rightarrow$A4 ist eine Abelische Gruppe bezüglich der Addition
-\item  $( \mathbb{R},+,\cdot)$ mit A1$\rightarrow$A4, M1$\rightarrow$M4 und D ist ein Zahlkörper. 
+\item $( \mathbb{R},+)$ mit A1$\to$A4 ist eine Abelische Gruppe bezüglich der Addition
+\item  $( \mathbb{R},+,\cdot)$ mit A1$\to$A4, M1$\to$M4 und D ist ein Zahlkörper. 
 \end{itemize}
 
 \subsubsection*{Bemerkung 2.2}
-Eine Menge $G$ versetzen mit Verknüpfung $+$ und Neutrales Element $O$ die den obigen Eigenschaften A2$\rightarrow$A4 genügen heisst Gruppe.\\
+Eine Menge $G$ versetzen mit Verknüpfung $+$ und Neutrales Element $O$ die den obigen Eigenschaften A2$\to$A4 genügen heisst Gruppe.\\
 
 Eine enge $K$ versetzen mit Verknüpfung $+,\cdot$ und Elementen $0\not =1$ die den obigen Eigenschaften 
-A1$\rightarrow$A4, M1$\rightarrow$M4, D genügen heisst Körper. 
+A1$\to$A4, M1$\to$M4, D genügen heisst Körper. 
 \newpage
 \subsubsection*{Folgerung 2.3}
 Seien $a,b,c,d\in\mathbb{R}$\\
@@ -335,10 +335,10 @@ Von der Mengentheorie können wir die Kartesische Produkt zweier Mengen; es Läs
 
 Für beliebige $n\geq 1$ betrachten wir$ \mathbb{R}^n: = \underbrace {\mathbb{R} \times  \ldots  \times \mathbb{R} }_{n - {\text{mal}}}$ und untersuchen Seine Struktur. Auf $\mathbb{R}^n$ haben wir zwei Verknüpfungen
 \begin{enumerate}
-    \item $+:\mathbb{R}^n\times\mathbb{R}^n\rightarrow\mathbb{R}^n$ Addition.\\
+    \item $+:\mathbb{R}^n\times\mathbb{R}^n\to\mathbb{R}^n$ Addition.\\
 $\left( {\underbrace {\left( {{x_1}, \ldots ,{x_n}} \right)}_x,\underbrace {\left( {{y_1}, \ldots ,{y_n}} \right)}_y} \right) \to \underbrace {\left( {{x_1} + {y_1}, \ldots ,{x_n} + {y_n}} \right)}_{{\text{Komponentenweise Addition}}}$. Dann ist $\left( \mathbb{R}^n,+\right)$ eine Abelische Gruppe, mit $0:=(0,\dots,0)$ aln neutrales Element
-\item $\cdot:\mathbb{R}\times\mathbb{R}^n\rightarrow\mathbb{R}^n$ Skalarmultiplikation.\\
-$(\lambda,x)\rightarrow\lambda\cdot x:=(\lambda x_1,\dots,\lambda x_n)$. Dann gelten die folgende Eigenschaften: $\forall x,y\in\mathbb{R}^n,\forall \alpha,\beta\in\mathbb{R}$ 
+\item $\cdot:\mathbb{R}\times\mathbb{R}^n\to\mathbb{R}^n$ Skalarmultiplikation.\\
+$(\lambda,x)\to\lambda\cdot x:=(\lambda x_1,\dots,\lambda x_n)$. Dann gelten die folgende Eigenschaften: $\forall x,y\in\mathbb{R}^n,\forall \alpha,\beta\in\mathbb{R}$ 
 \begin{enumerate}
 \item Distributivität: $\left( \alpha+\beta\right) x=\alpha x+\beta x$
 \item Distributivität: $\alpha\left(x+y\right) = \alpha x+\alpha y$
@@ -355,7 +355,7 @@ Also ist $\mathbb{R}^n$ ein Vektorraum. In der Linearen Algebra führt man dann 
 Jeder Vektor $x=\left(x_1,\dots,x_n \right)\in\mathbb{R}$ besitzt eine eindeutige Darstellung $x=\sum x_ie_i$ bezüglich der Standardbasis.
 \begin{definition}{2.16}
 \begin{enumerate}
-\item Das Skalarprodukt zweier Vektoren $x=\left(x_1,\dots,x_n \right),y=\left(y_1,\dots,y_n \right)$ ist die durch \[ < x,y > : = \sum\limits_{i = 1}^n {{x_i}{y_i}} \] definierte reele Zahl\\ $<\cdot,\cdot>=\mathbb{R}^n\times\mathbb{R}^n\rightarrow\mathbb{R}$ (orthogonal)
+\item Das Skalarprodukt zweier Vektoren $x=\left(x_1,\dots,x_n \right),y=\left(y_1,\dots,y_n \right)$ ist die durch \[ < x,y > : = \sum\limits_{i = 1}^n {{x_i}{y_i}} \] definierte reele Zahl\\ $<\cdot,\cdot>=\mathbb{R}^n\times\mathbb{R}^n\to\mathbb{R}$ (orthogonal)
 \item Falls $<x,y>=0$ heissen $x$ und $y$ senkrecht aufeinander. $<\cdot,\cdot>$ besitzt folgende Eigenschaften
 \begin{enumerate}
 \item Symmetrie: $<x,y>=<y,x>$
@@ -475,7 +475,7 @@ Das Problem ist hier, dass $\sqrt{-1}$ keinen präzisen Mathematisches Sinn hat 
 
 \noindent Das Problem is wie folgt gelöst:\\
 
-Als model von ``$a+b\sqrt{-1}$'', $\mathbb{C}$, nehmen wir $\mathbb{R}^2$. Wir haben schon eine Addition von vektoren und das neutral Element \todo{Chopped content, page 42 middle}. Wir definieren dann die Multiplikation \[\mathbb{R}^2 \times\mathbb{R}^2 \rightarrow \mathbb{R}^2\] \[(x,y)\rightarrow x\cdot y \]
+Als model von ``$a+b\sqrt{-1}$'', $\mathbb{C}$, nehmen wir $\mathbb{R}^2$. Wir haben schon eine Addition von vektoren und das neutral Element \todo{Chopped content, page 42 middle}. Wir definieren dann die Multiplikation \[\mathbb{R}^2 \times\mathbb{R}^2 \to \mathbb{R}^2\] \[(x,y)\mapsto x\cdot y \]
 wobei $x\cdot y=(ac-bd,ad+bc)$, $x=(a,b)$, $y=(c,d)$. Dann erfüllen ``$+$'' und ``$\cdot$'' folgende Eigenschaften:
 \begin{itemize}
 \item Assos: $\left((a,b)(c,d)\right)(e,f)=(a,b)\left((c,d)(e,f) \right)$
@@ -517,7 +517,7 @@ ASK FOR BEWEIS \todo{ASK FOR BEWEIS}
 \subsubsection*{Abkürzung}
 $\left| z\right| := \left|\left| z \right|\right|$
 \subsubsection*{Bemerkung 2.24}
-Wir können $\mathbb{R}$ in $\mathbb{C}$ ``einbetten'' mittels $\mathbb{R}\ni x\rightarrow (x,0)\in\mathbb{C}$. Sei $\mathbb{C}_0=\{ (x,y)\in\mathbb{C}\mid y=0 \}=\{ (x,0)\mid x\in\mathbb{R}\}$. Der Abbildung $f:\mathbb{R}\rightarrow\mathbb{C}_0$, $x\rightarrow (x,0)$ist eine Bijektion.\\
+Wir können $\mathbb{R}$ in $\mathbb{C}$ ``einbetten'' mittels $\mathbb{R}\ni x\to (x,0)\in\mathbb{C}$. Sei $\mathbb{C}_0=\{ (x,y)\in\mathbb{C}\mid y=0 \}=\{ (x,0)\mid x\in\mathbb{R}\}$. Der Abbildung $f:\mathbb{R}\to\mathbb{C}_0$, $x\mapsto (x,0)$ist eine Bijektion.\\
 
 Diese Identifikation (von $\mathbb{R}$ und $\mathbb{C}_0$ ist verträglich mit den operationen in $\mathbb{R}$ und in $\mathbb{C}$, d.h.
 \[f(x+y)=f(x)+f(y)\]

--- a/Tex/Chapters/Chapter_3.tex
+++ b/Tex/Chapters/Chapter_3.tex
@@ -1,7 +1,7 @@
 \chapter{Folgen und Reihen (Der Limes Begriff)}
 \section{Folgen, allgemeines}
 \begin{definition}{3.1}
-Eine Folge reeler zahlen ist eine Abbildung $a:\mathbb{N}\backslash\{0\}\rightarrow\mathbb{R}$ wobei wir das Bild con $n\geq 1$ mit $a_n$ (statt $a(n)$) bezeichen.\\
+Eine Folge reeler zahlen ist eine Abbildung $a:\mathbb{N}\backslash\{0\}\to\mathbb{R}$ wobei wir das Bild con $n\geq 1$ mit $a_n$ (statt $a(n)$) bezeichen.\\
 
 Eine Folge wird dann meistens mit $(a_n)_{n\geq 1}$, daher mit der geordneten Bildmenge bezeichnet.
 \end{definition}
@@ -96,7 +96,7 @@ Setzen wir $N_0:=\left( 1+\frac{2}{\varepsilon^2}\right)+1$. Dann gilt für $\fo
 \end{enumerate}
 
 \subsubsection*{Beispiel 3.7}
-Seien $p\in\mathbb{N}$, $0<q<1$. Dann gilt $\lim\limits_{n\rightarrow\infty}n^p q^n=0$. Dass heisst Exponentialfunktionen wächst schneller als jede Potenz (Wann $x$ genügend Gross ist, $a^x>x^b$)
+Seien $p\in\mathbb{N}$, $0<q<1$. Dann gilt $\lim\limits_{n\to\infty}n^p q^n=0$. Dass heisst Exponentialfunktionen wächst schneller als jede Potenz (Wann $x$ genügend Gross ist, $a^x>x^b$)
 
 \subsubsection*{Beweis}
 Der Trick ist folgender \[{n^p}{q^n} = {\left( {{n^{\frac{p}{n}}} \cdot q} \right)^n} = {\left( {{{\left( {\sqrt[n]{n}} \right)}^p}{{\left( {{q^{\frac{1}{p}}}} \right)}^p}} \right)^n}\] Wir werden Beispiel 3.6 (2.),(3.) benutzen. \\(d.h. $\lim\sqrt[n]{n}=1 \hspace{10mm}\lim r^n=0, 0<r<1$) \\

--- a/Tex/Chapters/Chapter_6.tex
+++ b/Tex/Chapters/Chapter_6.tex
@@ -4,17 +4,17 @@
 
 \begin{enumerate}[\indent I)]
 \item \begin{enumerate}[a)]
-\item Gegeben sei eine stetige Funktion $f : \lbrack a,b\rbrack \rightarrow \mathbb{R}$. Gesucht ist eine differenzierbare Funktion $F: \lbrack a,b\rbrack \rightarrow \mathbb{R}$ mit \[F'(t)=f(t), \forall t \in \lbrack a,b \rbrack\]
+\item Gegeben sei eine stetige Funktion $f : \lbrack a,b\rbrack \to \mathbb{R}$. Gesucht ist eine differenzierbare Funktion $F: \lbrack a,b\rbrack \to \mathbb{R}$ mit \[F'(t)=f(t), \forall t \in \lbrack a,b \rbrack\]
 \item Für Naturwissenschaft und Technik ist die folgende Verallgemeinerung von a) wichtig:\\
-Sei $f:\lbrack a,b\rbrack \times \mathbb{R} \rightarrow \mathbb{R}$ gegeben. Gesucht ist eine differenzierbare Funktion $\varphi : \lbrack a,b\rbrack \rightarrow \mathbb{R}$ mit \[\varphi ' (t)=f(t,\varphi (t)), t\in \lbrack a,b \rbrack\] Man nennt ein solches $\varphi$ eine Lösung der Differentialgleichung \[y'=f(x,y)\]
+Sei $f:\lbrack a,b\rbrack \times \mathbb{R} \to \mathbb{R}$ gegeben. Gesucht ist eine differenzierbare Funktion $\varphi : \lbrack a,b\rbrack \to \mathbb{R}$ mit \[\varphi ' (t)=f(t,\varphi (t)), t\in \lbrack a,b \rbrack\] Man nennt ein solches $\varphi$ eine Lösung der Differentialgleichung \[y'=f(x,y)\]
 \end{enumerate}
 \item Viele in der Natur und Ingenieurwissenschaften auftretenden Grössen benötigen zu ihrer exakten Definition einen Grenzprozess der Folgenden art: \\
 Wirkt eine konstante Kraft f längs eines Weges der Länge $s$, und zwar längs der $x$-Achse vom Punkt $a$ bis zum Punkt $b:=a+s$, so versteht man unter der von der konstanten Kraft f geleisteten Arbeit das Produkt f$\times s=$f$(b-a)$. \\
-Ist die Kraft f jedoch örtlich variable, d.h. $f:\lbrack a,b\rbrack \rightarrow \mathbb{R}$ eine Funktion des Ortes $x \in \lbrack a,b\rbrack$, so wird man folgendermasse vorgehen.\\
+Ist die Kraft f jedoch örtlich variable, d.h. $f:\lbrack a,b\rbrack \to \mathbb{R}$ eine Funktion des Ortes $x \in \lbrack a,b\rbrack$, so wird man folgendermasse vorgehen.\\
 
 Zerlege das Interval $\lbrack a,b\rbrack$ in kleine Teilintervalle $I_{1},\dots, I_{n}$. Wähle in jedem Interval $I_{k}:=\lbrack x_{k-1}, x_{k}\rbrack$ einen Punkt $\xi$ aus. Man wird dann die ``Riemannsche Summe'' \[A \sim  \sum\limits_{k = 1}^n {f({\xi_k})({x_k} - {x_{k - 1}})} \]  als Näherung für die gesuchte Arbeit $A$ ansehen. Hierzu wird man insbesondere dann berechtigt sein, wenn man mit jeder genügend feinen Zerlegung des Intervals $I$, einem festen Wert $A$ beliebig nahe kommt. 
 
-\item Sei $f: \lbrack a,b\rbrack \rightarrow \lbrack 0,\infty\rbrack$ eine (stetige) Funktion. Gesucht ist eine vernünftige Definition des Flächeninhalts A des Gebietes zwischen der $x$-Achse und dem Graphen von $f$
+\item Sei $f: \lbrack a,b\rbrack \to \lbrack 0,\infty\rbrack$ eine (stetige) Funktion. Gesucht ist eine vernünftige Definition des Flächeninhalts A des Gebietes zwischen der $x$-Achse und dem Graphen von $f$
 \begin{center}
 \begin{tikzpicture}
 
@@ -117,7 +117,7 @@ Um den genauen Wert der Fläche festzulegen bilden wir immer feinere Zerlegungen
 \end{enumerate}
 \section{Riemann Integral: Definition, elementare Eigenschaften}
 \begin{enumerate}
-\item Sei $f: \lbrack a,b\rbrack\rightarrow\mathbb{R}$ eine beschränkte Funktion.\\
+\item Sei $f: \lbrack a,b\rbrack\to\mathbb{R}$ eine beschränkte Funktion.\\
 
 \begin{definition}{6.1}
 Eine Partition (oder Zerlegung, Einteilung, Unterteilung) eines Intervalls $\lbrack a,b\rbrack$ ist eine endliche Menge $P=\{a=x_0,x_1.\dots,x_n=b \}\\
@@ -254,7 +254,7 @@ Addiert man dazu alle Summanden in \[O(f,P)=\sum\limits_i {(\mathop {\sup {\text
 mit $t\neq l$ so ergibt sich die Ungleichung \[O(f,Q)\leq O(f,P)\]
 Ebenso beweist man $U(f,Q)\geq U(f,P)$. Damit ist b) für den Fall bewiesen, dass $Q$ genau ein Element mehr als $P$ enthält. Der allgemeine Fall lässt sich hierauf leicht durch vollständige Induktion zurückführen. 
 
-\subsubsection*{Lemma 6.3} Sei $f:I:=\lbrack a,b \rbrack \rightarrow \mathbb{R}$ eine beschränkte Funktion. Dann gilt \[\mathop {\sup {\text{ }}U}\limits_{P \in P(I)} (f,P) \le \mathop {\inf {\text{ }}O}\limits_{P \in P(I)} (f,P)\]
+\subsubsection*{Lemma 6.3} Sei $f:I:=\lbrack a,b \rbrack \to \mathbb{R}$ eine beschränkte Funktion. Dann gilt \[\mathop {\sup {\text{ }}U}\limits_{P \in P(I)} (f,P) \le \mathop {\inf {\text{ }}O}\limits_{P \in P(I)} (f,P)\]
 
 \subsubsection*{Beweis}
 Aus \[P\subset Q \Rightarrow U(f,P) \leq U(f,Q) \leq O(f,Q) \leq O(f,P)\] folgt, dass die Zahl $O(f,Q)$ für jede Partition $Q\in P(I)$ eine obere Schranke für die Menge $\{ U(f,P)\mid P\in P(I)\}$ ist. Also folgt aus der Definition des Supremums als kleinste obere Schranke, dass $\mathop {\sup {\text{ }}U}\limits_{P \in P(I)} (f,P) \le \mathop O(f,Q)$ ist. \\
@@ -264,7 +264,7 @@ Diese Ungleichung gilt für jede Partition $Q\in P(I)$. Das heisst wiederum, das
 Also folgt aus der Definition der Infimums als grösste untere Schranke, dass die Gleichung $\mathop {\sup U}\limits_{P \in P(I)} (f,P) \le \mathop {\inf O}\limits_{Q \in P(I)} (f,Q)$ ist. Damit ist Lemma 6.3 bewiesen.
 \begin{definition}{6.4}
 \begin{enumerate}[\indent 1)]
-\item Für beschränktes $f=\lbrack a,b \rbrack\rightarrow \mathbb{R}$ bezeichnen 
+\item Für beschränktes $f=\lbrack a,b \rbrack\to \mathbb{R}$ bezeichnen 
 \[\int\limits_{\underline{a}}^b {fdx = \sup \{ U(f,P):P \in P(I)\} }\]
 \[\int\limits_{a}^{\overline{b}} {fdx = \inf \{ O(f,P):P \in P(I)\} }\]
 das Untere und Obere Integral von $f$.
@@ -274,7 +274,7 @@ das Untere und Obere Integral von $f$.
 
 \subsubsection*{Beispiel 6.5}
 \begin{enumerate}[\indent 1)]
-\item Sei $c\in \mathbb{R}$, $f:I\rightarrow \mathbb{R}$ die konstante Funktion mit dem Wert $c$, das heisst $f(x)=c, \forall x\in I$. Dann gilt \[U(f,P)=O(f,P)=(b-a)c, \forall P\in P(I)\] $\Rightarrow$ $f$ ist Riemann integrierbar und \[\int\limits_a^b {fdx}  = \int\limits_a^b {cdx = c(b - a)} \] In diesem einfachen Fall stimmt unsere Definition mit der Interpretation des Flächeninhalts als Breite mal Höhe überein. Man beachte, dass die Konstante $c$ auch negativ sein darf. 
+\item Sei $c\in \mathbb{R}$, $f:I\to \mathbb{R}$ die konstante Funktion mit dem Wert $c$, das heisst $f(x)=c, \forall x\in I$. Dann gilt \[U(f,P)=O(f,P)=(b-a)c, \forall P\in P(I)\] $\Rightarrow$ $f$ ist Riemann integrierbar und \[\int\limits_a^b {fdx}  = \int\limits_a^b {cdx = c(b - a)} \] In diesem einfachen Fall stimmt unsere Definition mit der Interpretation des Flächeninhalts als Breite mal Höhe überein. Man beachte, dass die Konstante $c$ auch negativ sein darf. 
 \item $f(x) = \left\{ {\begin{array}{*{20}{c}}
 {0{\text{ für }}x \ne {x_0}}\\
 {1{\text{ für }}x = {x_0}}
@@ -320,7 +320,7 @@ $\Rightarrow f$ ist nicht integrierbar. (f ist beschränkt aber nicht integrierb
 \end{enumerate}
 
 \subsubsection*{Satz 6.6 (Riemannsches Kriterium für Integrierbarkeit)}
-Sei $f:I\rightarrow\mathbb{R}$ eine beschränkte Funktion. Dann sind folgende Aussagen äquivalent
+Sei $f:I\to\mathbb{R}$ eine beschränkte Funktion. Dann sind folgende Aussagen äquivalent
 \begin{enumerate}
 \item $f(x)$ ist integrierbar über $\lbrack a,b\rbrack$
 \item Für jedes $\varepsilon>0$ existiert eine Partition $Q\in P(I)$ mit \[O(f,Q)-U(f,Q)<\varepsilon\]
@@ -351,12 +351,12 @@ Aus (b) folgt das $\forall\varepsilon>0$ \[0 < \int\limits_a^{\overline{b}} {f(x
 
 \subsubsection*{Satz 6.7}
 \begin{enumerate}
-\item Jede Stetige Funktion $f:I\rightarrow \mathbb{R}$ ist R. Integrierbar.
+\item Jede Stetige Funktion $f:I\to \mathbb{R}$ ist R. Integrierbar.
 \item Jede Monotone Funktion ist R. Integrierbar.
 \end{enumerate}
 \subsubsection*{Beweis}
 \begin{enumerate}
-\item $f:I\rightarrow\mathbb{R}$ stetig, $I=\lbrack a,b\rbrack$ kompakt, $\Rightarrow f$ gleichmässig stetig.\\
+\item $f:I\to\mathbb{R}$ stetig, $I=\lbrack a,b\rbrack$ kompakt, $\Rightarrow f$ gleichmässig stetig.\\
 d.h. zu jedem $\varepsilon >0$. gibt es $\delta >0$ mit \[\left| {x - y} \right| < \delta  \Rightarrow \left| {f(x) - f(y)} \right| < \frac{\varepsilon }{{b - a}}\]
 Für eine $P\in P(I)$ mit Feinheit $\delta(P)<\delta$ gilt dann \[O(f,P)-U(f,P)=\sum\limits_{i = 1}^n {(\mathop {\sup f}\limits_{[{x_{i - 1}},{x_i}]}  - \mathop {\inf f}\limits_{[{x_{i - 1}},{x_i}]} )} ({x_{i - 1}} - {x_i}) \]
 \[\le \sum\limits_{i = 1}^n {\frac{\varepsilon }{{b - a}}({x_i} - {x_{i - 1}}) = \frac{\varepsilon }{{b - a}}\sum\limits_{i = 1}^n {({x_i} - {x_{i - 1}})} }  = \varepsilon \]
@@ -369,28 +369,28 @@ Für jede $\varepsilon>0$, haben wir $\frac{{(b - a)(f(b) - f(a))}}{n} < \vareps
 \end{enumerate}
 
 \subsubsection*{Satz 6.8 (Riemannsche Summe)}
-Sei $f:I\rightarrow \mathbb{R}$ eine beschränkte Funktion. Folgende Aussagen sind äquivalent.
+Sei $f:I\to \mathbb{R}$ eine beschränkte Funktion. Folgende Aussagen sind äquivalent.
 \begin{enumerate}[\indent I)]
 \item $f$ ist Riemann Integrierbar und $A: = \int\limits_a^b {f(x)dx} $
 \item Für jedes $\varepsilon>0$, existiert eine Zahl $\xi>0$, so dass für jede Partition $P_i=\{x_0,x_1,\dots,x_N\}$ von $I$ und alle $\xi_i,\dots,\xi_N \in \mathbb{R}$ gilt \[\mathop {\delta (P) < \delta }\limits_{{x_{k - 1}} \le {\xi _k} \le {x_k},\forall k}  \Rightarrow \left| {A - \sum\limits_{k = 1}^N {f({\xi _k})({x_k} - {x_{k - 1}})} } \right| < \varepsilon \]
 \end{enumerate}
-Dieser Satz lässt sich auch so formulieren: Eine beschränkte Funktion $f:I\rightarrow\mathbb{R}$ ist genau dann Riemann integrierbar wenn der Grenzwert \[\mathop {\mathop {\lim }\limits_{\delta (P) \to 0} }\limits_{{\xi _k} \in [{x_{k - 1}},{x_k}]} \sum\limits_{k = 1}^N {f({\xi _k})({x_k} - {x_{k - 1}})} \] und dann haben wir \[A=\int\limits_a^b {f(x)dx = \mathop {\lim }\limits_{\delta (P) \to 0} } S(f,P,\delta )\]
+Dieser Satz lässt sich auch so formulieren: Eine beschränkte Funktion $f:I\to\mathbb{R}$ ist genau dann Riemann integrierbar wenn der Grenzwert \[\mathop {\mathop {\lim }\limits_{\delta (P) \to 0} }\limits_{{\xi _k} \in [{x_{k - 1}},{x_k}]} \sum\limits_{k = 1}^N {f({\xi _k})({x_k} - {x_{k - 1}})} \] und dann haben wir \[A=\int\limits_a^b {f(x)dx = \mathop {\lim }\limits_{\delta (P) \to 0} } S(f,P,\delta )\]
 
 \subsubsection*{Beweis} Siehe D.Salomon: Das Riemannsche Integrale (Satz 3.1).
 \subsubsection*{Korollar 6.8}
-Seien $f:\lbrack a,b\rbrack\rightarrow\mathbb{R}$ eine beschränkte und integrierbare Funktion. $\{ P^{(n)}\}$ eine Folge von Partitionen der Intervals $\lbrack a,b\rbrack$ mit $\delta(P^{(n)})\rightarrow 0$ für $n\rightarrow\infty$ und $\{\xi^{(n)}\}$ eine Feste Wahl von Zwischenpunkten zur Partition $P^{(n)}$. Dann ist
+Seien $f:\lbrack a,b\rbrack\to\mathbb{R}$ eine beschränkte und integrierbare Funktion. $\{ P^{(n)}\}$ eine Folge von Partitionen der Intervals $\lbrack a,b\rbrack$ mit $\delta(P^{(n)})\to 0$ für $n\to\infty$ und $\{\xi^{(n)}\}$ eine Feste Wahl von Zwischenpunkten zur Partition $P^{(n)}$. Dann ist
 \[\int\limits_a^b {f(x)dx = \mathop {\lim }\limits_{n \to \infty } S(f,{P^{(n)}},{\xi ^{(n)}})} \]
 \subsubsection*{Beweis}
 Wegen Satz 6.8 existiert zu jedem $\varepsilon>0$, ein $\delta>0$ derart, das für alle Partitionen $\delta(P)<\delta$ die Ungleichung 
 \[\left| {S(f,P,\xi ) - \int\limits_a^b {f(x)dx} } \right| < \varepsilon \]
 gilt und zwar bei beliebiger Wahl der Zwischenpunkten.\\
-Wegen  $\delta(P^{(n)})\rightarrow 0$ existiert ein $N\in\mathbb{N}$ mit $\delta(P^{(n)})<\delta$ für alle $n\geq N$.
+Wegen  $\delta(P^{(n)})\to 0$ existiert ein $N\in\mathbb{N}$ mit $\delta(P^{(n)})<\delta$ für alle $n\geq N$.
 Für jedes $n\geq N$ ist daher \[\left| {S(f,{P^{(n)}},\xi ) - \int\limits_a^b {f(x)dx} } \right| < \varepsilon \] voraus sich die Behauptung unmittelbar ergibt. 
 \subsubsection*{Beispiel}
 \[\int\limits_0^1 {({x^2} - x)dx = ?} \]
 $$f(x) = {x^2} - x \text{ stetig }\Rightarrow\text{ $f$ integrierbar}$$
 Wir wenden Korollar 6.8 an. Wir betrachten die Folge $\{ P^{(n)}\}$ von äquidistanten Partition des intervals $\lbrack 0,1\rbrack$ mit \[x_k^{(n)}: = \frac{k}{n},\text{\indent}\forall k = 0,1, \ldots ,n\]
-Dann $\delta(P^{(n)})=\frac{1}{n}\rightarrow 0$ für $n\rightarrow\infty$. Wir wählen die Zwischenpunkte 
+Dann $\delta(P^{(n)})=\frac{1}{n}\to 0$ für $n\to\infty$. Wir wählen die Zwischenpunkte 
 \[\xi _k^{(n)}: = \frac{k}{n},\text{\indent}\forall k = 1, \ldots ,n\]
 
 Die $\xi _k^{(n)}$ sind die rechten Endpunkte der Teilintervale $I_{k-1}:=\lbrack \frac{k-1}{n},\frac{k}{n}\rbrack$. Hiermit folgt
@@ -406,7 +406,7 @@ Die $\xi _k^{(n)}$ sind die rechten Endpunkte der Teilintervale $I_{k-1}:=\lbrac
 %%%%%%%%%%%%%%%%%%%%
 \subsection*{Eigenschaften des Integrals}
 \subsubsection*{Satz 6.9}
-Seien $a<c<b$ und $\alpha, \beta \in \mathbb{R}$ und $f,g:I=\lbrack a,b \rbrack\rightarrow\mathbb{R}$ zwei Reimann Integrierbare Funktionen. Dann gilt folgendes:
+Seien $a<c<b$ und $\alpha, \beta \in \mathbb{R}$ und $f,g:I=\lbrack a,b \rbrack\to\mathbb{R}$ zwei Reimann Integrierbare Funktionen. Dann gilt folgendes:
 \begin{enumerate}
 \item Die Funktion $\alpha f + \beta g$ ist integrierbar mit \[\int\limits_a^b {(\alpha f + \beta g)dx = \alpha \int\limits_a^b {f(x)dx + \beta \int\limits_a^b {g(x)dx} } } \]
 \item Wenn $f,g$ die Ungleichung $f(x)\leq g(x), \forall x\in\lbrack a,b\rbrack$ erfüllen, dann gilt \[\int\limits_a^b {f(x)dx \le \int\limits_a^b {g(x)dx} } \]
@@ -415,8 +415,8 @@ Seien $a<c<b$ und $\alpha, \beta \in \mathbb{R}$ und $f,g:I=\lbrack a,b \rbrack\
 \end{enumerate}
 
 \subsubsection*{Bemerkung 6.10}
-Wir bezeichnen die Menge aller Riemann integrierbaren Funktionen $f:I\rightarrow \mathbb{R}$ mit $R(I):=\{f:I\rightarrow\mathbb{R}\mid f$ R.Integrierbar $\}$. Nach Satz 6.9 i), ist dies ein reeler Vektorraum. $R(I)$ ist ein Unterraum des Vektorraumes aller reelwertigen Funktion \[F(I):=\{ f:I\rightarrow \mathbb{R}\}\]
-\[C(I):=\{ f:I\rightarrow\mathbb{R}\mid f \text{ stetig}\}\]
+Wir bezeichnen die Menge aller Riemann integrierbaren Funktionen $f:I\to \mathbb{R}$ mit $R(I):=\{f:I\to\mathbb{R}\mid f$ R.Integrierbar $\}$. Nach Satz 6.9 i), ist dies ein reeler Vektorraum. $R(I)$ ist ein Unterraum des Vektorraumes aller reelwertigen Funktion \[F(I):=\{ f:I\to \mathbb{R}\}\]
+\[C(I):=\{ f:I\to\mathbb{R}\mid f \text{ stetig}\}\]
 ist ein Unterraum von $R(I)$ \[C(I)\subset R(I)\subset F(I)\]
 \subsubsection*{Beweis 6.9}
 \begin{enumerate}
@@ -444,7 +444,7 @@ Nach Bmk. 6.2 $P_1\subset P$
 \[\Rightarrow U(f,P_1)<U(f,P)\] und \[O(f,P)<O(f,P_1)\]
 Dann \[-U(f,P)<-U(f,P_1)\] und \[O(f,P)-U(f,P)<O(f,P_1)-U(f,P_1)<\frac{\varepsilon}{(\left| \alpha  \right| + \left| \beta  \right|)}\]
 
-\item Seien $f,g:I\rightarrow\mathbb{R}$ integrierbar mit $f(x)\leq g(x), \forall x \in I$.\\
+\item Seien $f,g:I\to\mathbb{R}$ integrierbar mit $f(x)\leq g(x), \forall x \in I$.\\
 Die Funktion $h:=g-f$ ist wegen (1.) Integrierbar. Sei nur $P=\{x_0,x_1,\dots,x_n\}$ eine beliebige Partition von $\lbrack a,b\rbrack$ folgt dann $\inf h(x) \ge 0,\forall k = 0,1, \ldots ,n$ und daher \[U(h,P) = \sum\limits_P {(\inf h)({x_k} - {x_{k - 1}}) \ge 0} \]
 Was wiederum $\int\limits_{\underline{a}}^b {h(x)dx = \sup U(h,P) \ge 0} $ impliziert. \\
 Da $h$ aber integrierbar ist, folgt hieraus \[0 \le \int\limits_{\underline{a}}^b {h(x)dx = \int\limits_a^b {h(x)dx} } \]
@@ -480,7 +480,7 @@ Sei $f$ integrierbar über $\lbrack a,b \rbrack$. Dann gelten die Abschätzungen
 Für die Partition $P=\{ a,b\}$ von $\lbrack a,b\rbrack$ folgt sofort \[(b - a)\mathop {\inf }\limits_{[a,b]} f = U(f,P) \le \int\limits_a^b {f(x)dx < O(f,P) = (b - a)\mathop {\sup }\limits_{[a,b]} f} \]
 
 \subsubsection*{Satz 6.11}
-Sei $f:\lbrack a,b\rbrack\rightarrow\mathbb{R}$ integrierbar. Dann ist $f$ auch auf jedem Teilinterval $\lbrack c,d\rbrack\subseteq\lbrack a,b\rbrack$ integrierbar. \\
+Sei $f:\lbrack a,b\rbrack\to\mathbb{R}$ integrierbar. Dann ist $f$ auch auf jedem Teilinterval $\lbrack c,d\rbrack\subseteq\lbrack a,b\rbrack$ integrierbar. \\
 
 \subsubsection*{Beweis}
 $f$ ist auf $\lbrack a,b\rbrack$ integrierbar wegen Satz 6.6.\\
@@ -498,7 +498,7 @@ und, analog
 \[M^{''}_{k}\left( f\right) =\sup _{I_k\in P''}f\]
 
 \subsubsection*{Satz 6.12}
-Seien $a\leq b\leq c$. Die funktion $f:\lbrack a,c\rbrack\rightarrow\mathbb{R}$ ist genau dann integrierbar falls beide Einschrankungen ${\left. f \right|_{[a,b]}}$ und ${\left. f \right|_{[b,c]}}$ integrierbar sind. In diesem Fall gilt \[\int\limits_a^c {f(x)dx = \int\limits_a^b {f(x)dx + \int\limits_b^c {f(x)dx} } } \]
+Seien $a\leq b\leq c$. Die funktion $f:\lbrack a,c\rbrack\to\mathbb{R}$ ist genau dann integrierbar falls beide Einschrankungen ${\left. f \right|_{[a,b]}}$ und ${\left. f \right|_{[b,c]}}$ integrierbar sind. In diesem Fall gilt \[\int\limits_a^c {f(x)dx = \int\limits_a^b {f(x)dx + \int\limits_b^c {f(x)dx} } } \]
 \subsubsection*{Konvention 6.13}
 \begin{enumerate}[\indent 1)]
 \item Sei $f$ integrierbar auf einem interval $I$. Für $a\leq b$ in $I$ definiert man \[\int\limits_b^a {f(x)dx =  - \int\limits_a^b {f(x)dx} } \]
@@ -509,7 +509,7 @@ Mit diesem Konvention gelten alle bisherigen Eigenschaften. z.B. \[\forall a,b,c
 In diesem Kapitel wird dem Zusammenhang zwischen Differentiation und Integration hergestellt. Zu diesem Zweck beginnen wir mit dem folgenden Satz, Mittelwertsatz der Integralrechnung. \\
 
 \subsubsection*{Satz 6.14 (Mws. der Integralrechnung)}
-Sei $f:\lbrack a,b\rbrack\rightarrow\mathbb{R}$ eine stetige Funktion. Dann existiert ein $\xi\in\lbrack a,b\rbrack$ mit \[\int\limits_a^b {f(x)dx = f(\xi )(b - a)} \] 
+Sei $f:\lbrack a,b\rbrack\to\mathbb{R}$ eine stetige Funktion. Dann existiert ein $\xi\in\lbrack a,b\rbrack$ mit \[\int\limits_a^b {f(x)dx = f(\xi )(b - a)} \] 
 
 Geometrisch:
 
@@ -568,25 +568,25 @@ Wegen Satz 6.10
 Also $\frac{1}{{b - a}}\int\limits_a^b {f(x)dx \le M} $ für ein $M\in\lbrack m,M\rbrack$. Da $f$ stetig ist, wegen Zwischenwertsatz gibt es $\xi\in\lbrack a,b\rbrack$ mit $f(\xi ) = \frac{1}{{b - a}}\int\limits_a^b {f(x)dx} $. Nun kommt die erste Hauptsatz der Diff- und Integralrechnung.\\
 
 \subsubsection*{Satz 6.15 (Hauptsatz A)}
-Sei $f:\lbrack a,b\rbrack\rightarrow\mathbb{R}$ eine stetige Funktion. Definiere für jeder $x\in\lbrack a,b\rbrack$ \[F(x): = \int\limits_x^b {f(t)dt} \]
-Dann ist $F:I\rightarrow\mathbb{R}$ differenzierbar und $F'(x)=f(x)\text{, }\forall x \in\lbrack a,b\rbrack$.\\
+Sei $f:\lbrack a,b\rbrack\to\mathbb{R}$ eine stetige Funktion. Definiere für jeder $x\in\lbrack a,b\rbrack$ \[F(x): = \int\limits_x^b {f(t)dt} \]
+Dann ist $F:I\to\mathbb{R}$ differenzierbar und $F'(x)=f(x)\text{, }\forall x \in\lbrack a,b\rbrack$.\\
 \subsubsection*{Beweis}
 Für jedes $h\neq 0$ ist \[\frac{{F(x + h) - F(x)}}{h} = \frac{1}{h}\left[ {\int\limits_a^{x + h} {f(t)dt}  - \int\limits_a^x {f(t)dt} } \right] \mathop  = \limits^{6.12}  \frac{1}{h}\int\limits_a^{x + h} {f(t)dt} \]
 Nach dem Mws der Integralrechnung existiert zu jedem solchen $h\neq 0$ ein Zwischenpunkt $\xi_h\in\lbrack x,x+h\rbrack$ (bzw. $\xi_h\in\lbrack x + h,x\rbrack$ falls $h<0$) mit \[\int\limits_x^{x + h} {f(t)dt = (h)f({\xi _h})} \]
-Nun ist $\xi_h \rightarrow x$ für $h\rightarrow 0$. Da $f$ stetig ist \[f(\xi_h)\rightarrow f(x) \text{ für } h\rightarrow 0\]
+Nun ist $\xi_h \to x$ für $h\to 0$. Da $f$ stetig ist \[f(\xi_h)\to f(x) \text{ für } h\to 0\]
 Damit erhalten wir \[F'(x) = \mathop {\lim }\limits_{h \to 0} \frac{{F(x + h) - F(x)}}{h} = \mathop {\lim }\limits_{h \to 0} \frac{1}{h}\int\limits_x^{x + h} {f(t)dt = } \mathop {\lim }\limits_{h \to 0} \frac{1}{h}(hf({\xi _h})) = f(x)\]
 Folgender Begriff ist dann naheliegend. \\
 
 \begin{definition}{6.16}
- Sei $f:\lbrack a,b\rbrack\rightarrow\mathbb{R}$ eine Funktion. Ein Stammfunktion von $f$ (auf $a,b$) ist ein differenzierbare Funktion $F:\lbrack a,b\rbrack\rightarrow\mathbb{R}$ mit $F'(x)=f(x)$.\\
+ Sei $f:\lbrack a,b\rbrack\to\mathbb{R}$ eine Funktion. Ein Stammfunktion von $f$ (auf $a,b$) ist ein differenzierbare Funktion $F:\lbrack a,b\rbrack\to\mathbb{R}$ mit $F'(x)=f(x)$.\\
 \end{definition}
 \noindent Wegen Satz 6.15, hat jede stetige Funktion mindestens eine Stammfunktion. Mit Ausnahme einer additiven Konstante, die beim Differenzieren ja wegfällt, ist die Stammfunktion auch eindeutig bestimmt. Dies ist der Inhalt des folgendes Satzes.\\
 
 \subsubsection*{Satz 6.17}
-Seien $I\subset \mathbb{R}$ ein beliebiges Interval und $F:I\rightarrow\mathbb{R}$ eine Stammfunktion von $f:I\rightarrow\mathbb{R}$. Dann gelten:
+Seien $I\subset \mathbb{R}$ ein beliebiges Interval und $F:I\to\mathbb{R}$ eine Stammfunktion von $f:I\to\mathbb{R}$. Dann gelten:
 \begin{enumerate}[\indent (a)]
 \item Die Funktion $F+c$ ist für jede Konstante $c\in\mathbb{R}$ ebenfalls eine Stammfunktion von $f$.
-\item Ist $G:I\rightarrow\mathbb{R}$ eine weitere Stammfunktion von $f$, so gibt es eine Konstante $c\in\mathbb{R}$ mit $G=F+c$
+\item Ist $G:I\to\mathbb{R}$ eine weitere Stammfunktion von $f$, so gibt es eine Konstante $c\in\mathbb{R}$ mit $G=F+c$
 \end{enumerate}
 
 \subsubsection*{Beweis}
@@ -599,11 +599,11 @@ Seien $I\subset \mathbb{R}$ ein beliebiges Interval und $F:I\rightarrow\mathbb{R
  Eine Stammfunktion von $f$ heisst auch unbestimmtes Integral von $f$ und wird bezeichnet mit $\int {f(x)dx} $. Mittels einer Stammfunktion lässt sich das Integral einer gegebenen Abbildung sehr leicht berechnen. Dies ist der Inhalt des Hauptsatz B.\\
 \end{definition}
 \subsubsection*{Satz 6.19 (Hauptsatz der Diff- und Integralberechnung Version B)}
-Sei $f:I\rightarrow\mathbb{R}$ eine stetige Funktion und $F$ eine beliebige Stammfunktion von $f$. Dann gilt \[\int\limits_a^b {f(x)dx = F(b) - F(a): = \left. {F(x)} \right|_a^b}\text{,\indent}\forall a,b\in I \]
+Sei $f:I\to\mathbb{R}$ eine stetige Funktion und $F$ eine beliebige Stammfunktion von $f$. Dann gilt \[\int\limits_a^b {f(x)dx = F(b) - F(a): = \left. {F(x)} \right|_a^b}\text{,\indent}\forall a,b\in I \]
 
 \subsubsection*{Beweis}
 Für $x\in I$ definieren wor \[F_0(x):=\int\limits_a^x {f(t)dt} \]
-Dann ist $F_0:I\rightarrow\mathbb{R}$ wegen Satz 6.15 eine (Spezielle) Stammfunktion von $f$ mit \[{F_0}(0) = 0\text{\indent}{F_0}(b) = \int\limits_c^b {f(t)dt} \]
+Dann ist $F_0:I\to\mathbb{R}$ wegen Satz 6.15 eine (Spezielle) Stammfunktion von $f$ mit \[{F_0}(0) = 0\text{\indent}{F_0}(b) = \int\limits_c^b {f(t)dt} \]
 Für die beliebige Stammfunktion $F$ gilt somit $F-F_0=c$ für eine Konstante $c\in\mathbb{R}$. Deshalb ist \[F(b) - F(a) = {F_0}(b) - {F_0}(a) = {F_0}(b) = \int\limits_a^b {f(t)dt} \] womit alles bewiesen ist. \\
 
 Der Satz 6.19 ist das zentrale Ergebnis und zur Berechnung konkreter Integral. Man Benötigt nur eine Stammfunktion uns hat von dieser lediglich die Differenz der Funktionswerte zwischen den beiden Endpunkten des Intervals $\lbrack a,b\rbrack$ zu bilden. 
@@ -652,7 +652,7 @@ Partielle Integration ist eine Umkehrung der Leibnizschen Produktregel und besag
 \end{array}\]
 
 \subsubsection*{Satz 6.21 (Partielle Integration)}
-Seien $f,g:\lbrack a,b\rbrack\rightarrow\mathbb{R}$ zwei stetig differenzierbare Funktionen. Dann gilt 
+Seien $f,g:\lbrack a,b\rbrack\to\mathbb{R}$ zwei stetig differenzierbare Funktionen. Dann gilt 
 \[\int {f(x)g'(x)dx = f(x)g(x) - \int {f'(x)g(x)dx} } \]
 und
 \[\int\limits_a^b {f(x)g'(x)dx = \left. {f(x)g(x)} \right|_a^b - \int\limits_a^b {f'(x)g(x)dx} } \]
@@ -798,15 +798,15 @@ Methode der Substitution ist eine Umkehrung der Kettenregel.
 \subsubsection*{Satz 6.25 (Substitutionsregel)}
 Sei 
 \begin{itemize}
-\item $f:\lbrack a,b\rbrack\rightarrow\mathbb{R}$ stetig
-\item $g:\lbrack\alpha,\beta\rbrack\rightarrow\mathbb{R}$ der klasse $C'$
+\item $f:\lbrack a,b\rbrack\to\mathbb{R}$ stetig
+\item $g:\lbrack\alpha,\beta\rbrack\to\mathbb{R}$ der klasse $C'$
 \end{itemize}
 Sowie $t_0\leq t_1$ in $\lbrack\alpha,\beta\rbrack$ so dass $g\left(\lbrack t_0, t_1\rbrack\right)\subset\lbrack a,b\rbrack$.
 Dann gilt 
 \[\int\limits_{g({t_0})}^{g({t_1})} {f(x)dx = \int\limits_{{t_0}}^{{t_1}} {f\left( {g\left( t \right)} \right)g'\left( t \right)dt} } \]
 
 \subsubsection*{Beweis}
-Sei $F:\lbrack a,b\rbrack\rightarrow\mathbb{R}$ eine Stammfunktion für $f$. Dann gilt (nach Hauptsatz B)
+Sei $F:\lbrack a,b\rbrack\to\mathbb{R}$ eine Stammfunktion für $f$. Dann gilt (nach Hauptsatz B)
 \[\int\limits_{g({t_0})}^{g({t_1})} {f(x)dx = F\left( {g({t_1})} \right)}  - F\left( {g({t_0})} \right)\]
 Nach der Kettenregel, haben wir
 \[(F \circ g)'(t) = F'(g(t))g'(t) = f(g(t))g'(t)\]
@@ -823,7 +823,7 @@ Für die Substitutionsregel
 gibt es im Prinzip zwei lesarten.
 \noindent Mann kann sie entweder von links nach rechts oder von rechts nach links anwenden: 
 \begin{enumerate}
-\item (links $\rightarrow$ rechts)\\
+\item (links $\to$ rechts)\\
 Liegt ein Integral explizit in der Form \[\int\limits_{{t_0}}^{{t_1}} {f\left( {g(t)} \right)g'(t)dt} \text{ vor,}\] so können wir die Substitutionsregel von links nach rechts abwende
 \subsubsection*{Beispiel}
 \begin{enumerate}
@@ -842,7 +842,7 @@ Liegt ein Integral explizit in der Form \[\int\limits_{{t_0}}^{{t_1}} {f\left( {
 \[ =  - \log \left| {\cos t} \right| + C\]
 
 \end{enumerate}
-\item (rechts $\rightarrow$ links)\\
+\item (rechts $\to$ links)\\
 Ein integral liegt der Gestalt $\int\limits_\alpha ^\beta  {f(x)dx}$ mit gewissen Grenzen $\alpha,\beta\in\mathbb{R}$ vor, das schwer zu berechnen scheint, versucht man dann mittels geeigneten Substitution $x=g(t)$, dieses Integral umzuformulieren, so dass die Substitutionsregel anwendbar ist, wobei $g(t_0)=\alpha$ und $g(t_1)=\beta$ gelten muss. 
 \subsubsection*{Beispiel 6.26}
 \begin{enumerate}
@@ -1008,12 +1008,12 @@ Sei $f$ eine Funktion auf einem offenen Interval $(a,b)$, deren Einschränkung a
 \subsubsection*{Beispiel}
 \[\int\limits_{ - b}^b {xdx = 0} \text{\hspace{10mm}}\forall b>0\text{, und daher}\]
 \[\mathop {\lim }\limits_{b \to \infty } \int\limits_{ - b}^b {xdx = \lim \left( {\frac{{{b^2}}}{2} - \frac{{{b^2}}}{2}} \right) = \mathop {\lim }\limits_{b \to \infty } 0 = 0} \]
-Die einzelnen Grenzwerte von $\int\limits_a^b {xdx} $ für $b\rightarrow \infty$ und $a\rightarrow -\infty$ existieren dagegen nicht \[\left( {\int\limits_a^b {xdx = \left. {\frac{{{x^2}}}{2}} \right|_a^b = \frac{{{b^2}}}{2} - \frac{{{a^2}}}{2}} } \right)\] und somit auch nicht das uneigentliche Integral $\int\limits_{ - \infty }^\infty  {xdx} $
+Die einzelnen Grenzwerte von $\int\limits_a^b {xdx} $ für $b\to \infty$ und $a\to -\infty$ existieren dagegen nicht \[\left( {\int\limits_a^b {xdx = \left. {\frac{{{x^2}}}{2}} \right|_a^b = \frac{{{b^2}}}{2} - \frac{{{a^2}}}{2}} } \right)\] und somit auch nicht das uneigentliche Integral $\int\limits_{ - \infty }^\infty  {xdx} $
 \item Alle Grundeigenschaften und Integrationstechniken für das bestimmte Integral gelten ebenso für das uneigentliche Integral. 
 \end{enumerate}
 Als Beispiel beweisen wir folgendes nützliches Konvergenzkriterium für Reihen
 \subsubsection*{Satz 6.30}
-Sei $f:\lbrack 1,\infty )\rightarrow \mathbb{R}_+$ monoton fallend. Dann konvergiert $\sum\limits_{k = 1}^\infty  {f(k)}$ genau dann wann $\int\limits_1^\infty  {f(x)dx} $ existiert. In diesem Fall gilt: \[0 \le \sum\limits_{k = 1}^\infty  {f(k)}  - \int\limits_1^\infty  {f(x)dx}  \le f(1)\]
+Sei $f:\lbrack 1,\infty )\to \mathbb{R}_+$ monoton fallend. Dann konvergiert $\sum\limits_{k = 1}^\infty  {f(k)}$ genau dann wann $\int\limits_1^\infty  {f(x)dx} $ existiert. In diesem Fall gilt: \[0 \le \sum\limits_{k = 1}^\infty  {f(k)}  - \int\limits_1^\infty  {f(x)dx}  \le f(1)\]
 \subsubsection*{Beweis}
 \begin{center}
 \begin{tikzpicture}[scale=0.7]
@@ -1074,7 +1074,7 @@ und
 \[ \Rightarrow \frac{1}{{s - 1}}\sum\limits_{n = 1}^\infty  {{n^{ - s}}}  \le 1 + \frac{1}{{s - 1}} = \frac{s}{{s - 1}}\]
 \item \[\int\limits_{ - \infty }^\infty  {\left| x \right|{e^{ - {x^2}}}dx}  =  - \int\limits_{ - \infty }^0 {x{e^{ - {x^2}}}dx}  + \int\limits_0^\infty  {x{e^{ - {x^2}}}dx}  = 2\int\limits_0^\infty  {x{e^{ - {x^2}}}dx} \]
 \[\int\limits_0^b {x{e^{ - {x^2}}}dx = \frac{1}{2}\int\limits_0^{{b^2}} {{e^{ - u}}du} }\text{\hspace{10mm} mit }u=x^2, du=2xdx \]
-\[ = \frac{1}{2}\left( {1 - {e^{ - {b^2}}}} \right) \to \frac{1}{2}\text{ für }b\rightarrow \infty\]
+\[ = \frac{1}{2}\left( {1 - {e^{ - {b^2}}}} \right) \to \frac{1}{2}\text{ für }b\to \infty\]
 Somit gilt \[\int\limits_{ - \infty }^\infty  {\left| x \right|{e^{ - {x^2}}}dx = 1} \]
 \item Wir haben die folgende einfache aber wichtige Beispiele
 \begin{enumerate}
@@ -1099,7 +1099,7 @@ Somit gilt \[\int\limits_{ - \infty }^\infty  {\left| x \right|{e^{ - {x^2}}}dx 
 \end{enumerate}
 \subsubsection*{Satz 6.32 (Majorantenkriterium)}
 \begin{enumerate}[\indent a)]
-\item Sei $f:\lbrack a,\infty )\rightarrow\mathbb{R}$ stetig. Dann gilt \[\forall x:\left| f(x)\right| <g(x)\] und $\int\limits_a^\infty  {g(x)}$ konvergent $\Rightarrow \int {f(x)dx} $ (absolut) konvergent.
+\item Sei $f:\lbrack a,\infty )\to\mathbb{R}$ stetig. Dann gilt \[\forall x:\left| f(x)\right| <g(x)\] und $\int\limits_a^\infty  {g(x)}$ konvergent $\Rightarrow \int {f(x)dx} $ (absolut) konvergent.
 \item Weiterhin gilt folgende Umkehrung: $\forall x:0\leq g(x)\leq f(x)$ und $\int\limits_a^\infty  {g(x)}$ divergent $\Rightarrow \int\limits_a^\infty  {f(x)}$ divergent.
 \end{enumerate}
 

--- a/Tex/Chapters/Chapter_8.tex
+++ b/Tex/Chapters/Chapter_8.tex
@@ -1,11 +1,11 @@
 \chapter{Differentialrechnung in $\mathbb{R}^{\lowercase{n}}$}
 \section{Partielle Ableitungen und Differential}
-Wie kann man die Begriffe der \todo{Missing content?? page 113 top} Differentialrechnung auf Funktionen $f:\Omega \subset \mathbb{R}^n\rightarrow\mathbb{R}$ erweitern?\\
+Wie kann man die Begriffe der \todo{Missing content?? page 113 top} Differentialrechnung auf Funktionen $f:\Omega \subset \mathbb{R}^n\to\mathbb{R}$ erweitern?\\
 
 Funktion in mehreren variablen sind ein bisschen komplizierter als Funktionen in einer variable.
 \subsubsection*{Beispiel}
 \begin{enumerate}
-\item $f(x)=x^2+5$ ist in ursprung stetig da $\lim\limits_{x\rightarrow 0}f(x)=f(0)$. Aber $f:\mathbb{R}^2\rightarrow\mathbb{R}$ \[f(x,y) = \left\{ {\begin{array}{*{20}{c}}
+\item $f(x)=x^2+5$ ist in ursprung stetig da $\lim\limits_{x\to 0}f(x)=f(0)$. Aber $f:\mathbb{R}^2\to\mathbb{R}$ \[f(x,y) = \left\{ {\begin{array}{*{20}{c}}
 {\frac{{xy}}{{{x^2} + {y^2}}}}&{(x,y)\not  = (0,0)}\\
 0&{(x,y) = (0,0)}
 \end{array}} \right.\] ist im Ursprung nicht stetig. %page 114 top
@@ -41,9 +41,9 @@ Aber der Limes entlang der Gerade $y=mx$
 \end{array}} \]
 und $\frac{m}{1+m^2}\not=0$, falls $m\not=0$. Eine funktion $f(x,y)$ an der stelle $(x_0,y_0)$ ist stetig wenn der limes $\mathop {\lim }\limits_{(x,y) \to ({x_0},{y_0})} f(x,y)$ in jeder Richtung der gleichen wert haben. 
 \begin{definition}{8.1}
-Sei $\Omega\subset\mathbb{R}^n$, $f:\Omega \rightarrow\mathbb{R}$, $a\in\Omega$
+Sei $\Omega\subset\mathbb{R}^n$, $f:\Omega \to\mathbb{R}$, $a\in\Omega$
 \begin{enumerate}
-\item $f$ hat den Grenzwert $c\in\mathbb{R}$, d.h \[\lim\limits_{x\rightarrow a} f(x)=c\] ween es zu jeder (Beliebig kleinen) Schranke $\varepsilon>0$, eine $\delta$-umgebung \[{B_\delta }(a): = \left\{ {x \in \mathbb{R}^n}\mid\left| {x - a} \right| < \delta  \right\}\] gibt, so dass $\left| {f(x) - a} \right| < \varepsilon$ für alle $x\in\Omega\cap B_\delta (a), x\not=a$ gilt
+\item $f$ hat den Grenzwert $c\in\mathbb{R}$, d.h \[\lim\limits_{x\to a} f(x)=c\] ween es zu jeder (Beliebig kleinen) Schranke $\varepsilon>0$, eine $\delta$-umgebung \[{B_\delta }(a): = \left\{ {x \in \mathbb{R}^n}\mid\left| {x - a} \right| < \delta  \right\}\] gibt, so dass $\left| {f(x) - a} \right| < \varepsilon$ für alle $x\in\Omega\cap B_\delta (a), x\not=a$ gilt
 \item $f$ heisst in $a\in\Omega$ stetig, wenn $\mathop {\lim }\limits_{x \to a} f'(x) = f(a)$ gilt.
 \item $f$ heisst in $\Omega$ stetig, wenn $f$ in allen $a\in\Omega$ stetig ist. 
 \end{enumerate}
@@ -53,7 +53,7 @@ $f$ besitzt keinen Grenzwert in $x_0$ wenn sich bei Annäherungen an $x_0$ auf v
 \end{definition}
 
 \subsection*{Sandwichlemma}
-Sei $f,g,h$ funktionen wobei $g<f<h$. Wenn $\mathop {\lim }\limits_{x \to a} g = L = \mathop {\lim }\limits_{x \to a} h$ gilt, dann ergibt $\lim\limits_{x\rightarrow a}f=L$.\\
+Sei $f,g,h$ funktionen wobei $g<f<h$. Wenn $\mathop {\lim }\limits_{x \to a} g = L = \mathop {\lim }\limits_{x \to a} h$ gilt, dann ergibt $\lim\limits_{x\to a}f=L$.\\
 
 \noindent Da $\mathop {\lim }\limits_{(x,y) \to (0,0)} \left| y \right| = 0$ gilt, $\mathop {\lim }\limits_{(x,y) \to (0,0)} f(x,y) = 0 \Rightarrow f$ ist in (0,0) stetig.\\
 
@@ -95,14 +95,14 @@ Eine trickreiche Variante Grenzwerte zu berechnen, ergibt sich durch substitutio
 
 \noindent\textbf{\underline{Was bedeutet die Ableitung in einiger Richtung?}}
 \subsubsection*{Beispiel}
-Sei \[f:\mathbb{R}^2\rightarrow \mathbb{R}\]\[(x,y)\rightarrow \left(x^2+xy\right)\cos(xy)\]Man kann für jedes $y$, die Funktion \[\mathbb{R}\rightarrow\mathbb{R}\]\[x\rightarrow \left( x^2+xy\right)\left(\cos xy\right)\]als Funktion einer Variablen $x$ auflassen und die Ableitung davon berechnen. Das Resultat mit $\frac{\partial f}{\partial x}$ bezeichnet, ist die erste partielle Ableitung von $f$ nach $x$. In diesem fall ist es durch \[\frac{{\partial f}}{{\partial x}}(x,y) = (2x + y)(\cos xy) - ({x^2} + xy)y\sin (xy)\] gegeben. \\
+Sei \[f:\mathbb{R}^2\to \mathbb{R}\]\[(x,y)\to \left(x^2+xy\right)\cos(xy)\]Man kann für jedes $y$, die Funktion \[\mathbb{R}\to\mathbb{R}\]\[x\to \left( x^2+xy\right)\left(\cos xy\right)\]als Funktion einer Variablen $x$ auflassen und die Ableitung davon berechnen. Das Resultat mit $\frac{\partial f}{\partial x}$ bezeichnet, ist die erste partielle Ableitung von $f$ nach $x$. In diesem fall ist es durch \[\frac{{\partial f}}{{\partial x}}(x,y) = (2x + y)(\cos xy) - ({x^2} + xy)y\sin (xy)\] gegeben. \\
 
 \noindent Analog definiert man $\frac{\partial f}{\partial y}$\[\frac{{\partial f}}{{\partial y}}(x,y) = x(\cos xy) - ({x^2} + xy)x\sin (xy)\] Die allgemeine Definition nimmt folgende Gestallt ein. Sei $\Omega \subset\mathbb{R}^n$. In zukunft  bezeichnen wir die $i-$te Koordinate eines Vektors $x\in\mathbb{R}^n$ mit $x^i$; also ist $x=\left( x^1,x^2,\dots,x^n\right)$.\\
 
 \noindent Sei $e_i:=\left( 0,\dots,0,1,0,\dots,0\right)$ der $i-$te Basisvektor von $\mathbb{R}^n$
 
 \begin{definition}{8.2}
-Die Funktion $f:\Omega\subset\mathbb{R}^n\rightarrow\mathbb{R}$ heisst an der stelle $x_0\in\Omega$ in Richtung $e_i$ (oder nach $x^i$) partielle differenzierbar falls der limes \[\frac{{\partial f}}{{\partial {x^i}}}({x_0}) = {f_{{x^i}}}({x_0}): =  - \mathop {\lim }\limits_{\begin{array}{*{20}{c}}
+Die Funktion $f:\Omega\subset\mathbb{R}^n\to\mathbb{R}$ heisst an der stelle $x_0\in\Omega$ in Richtung $e_i$ (oder nach $x^i$) partielle differenzierbar falls der limes \[\frac{{\partial f}}{{\partial {x^i}}}({x_0}) = {f_{{x^i}}}({x_0}): =  - \mathop {\lim }\limits_{\begin{array}{*{20}{c}}
 {h \to 0}\\
 {h\not  = 0}
 \end{array}} \frac{{f({x_0} + h{e_i}) - f({x_0})}}{h}\]
@@ -114,7 +114,7 @@ existiert
 \end{definition}
 \subsubsection*{Bemerkung 8.3}
 \missingfigure{page 121, middle}
-Sei $f:\mathbb{R}^2\rightarrow\mathbb{R}, \left(x_0^1,x_0^2\right)\in\mathbb{R}^2$. Wir betrachten die scharen von $f$ \[f(\cdot ,x_0^2):\mathbb{R}\rightarrow \mathbb{R}\] und \[f(x_0^1,\cdot ):\mathbb{R}\rightarrow\mathbb{R}\] $\frac{\partial f}{\partial x^1}$, $\frac{\partial f}{\partial x^2}$ sind die Ansteig der Tangente zur entsprechende schrittkurven
+Sei $f:\mathbb{R}^2\to\mathbb{R}, \left(x_0^1,x_0^2\right)\in\mathbb{R}^2$. Wir betrachten die scharen von $f$ \[f(\cdot ,x_0^2):\mathbb{R}\to \mathbb{R}\] und \[f(x_0^1,\cdot ):\mathbb{R}\to\mathbb{R}\] $\frac{\partial f}{\partial x^1}$, $\frac{\partial f}{\partial x^2}$ sind die Ansteig der Tangente zur entsprechende schrittkurven
 
 \subsubsection*{Beispiel}
 \begin{enumerate}
@@ -132,7 +132,7 @@ Sei $f:\mathbb{R}^2\rightarrow\mathbb{R}, \left(x_0^1,x_0^2\right)\in\mathbb{R}^
 \[\frac{{\partial f}}{{\partial y}}(0,0) = \mathop {\lim }\limits_{h \to 0} \frac{{f(0,h) - f(0,0)}}{h} = \lim \frac{{\frac{{h \cdot {0^3}}}{{0 + {h^2}}} - 0}}{h} = 0\]
 \end{enumerate}
 \subsubsection*{Bemerkung}
-Für Funktionen $f:\mathbb{R}\rightarrow\mathbb{R}$ einer variable impliziert die differenzierbarkeit in $x_0$, die Stetigkeit in $x_0$ und zudem eine gute Approximation von $f$ durch eine affine Funktion in einer Umgebung von $x_0$. Folgendes Beispiel zeigt, dass in $\mathbb{R}^n$ $(n\geq 2)$ Partielle Differenzierbarkeit keine analoges  Approximationseigenschaften oder stetigkeit impliziert:
+Für Funktionen $f:\mathbb{R}\to\mathbb{R}$ einer variable impliziert die differenzierbarkeit in $x_0$, die Stetigkeit in $x_0$ und zudem eine gute Approximation von $f$ durch eine affine Funktion in einer Umgebung von $x_0$. Folgendes Beispiel zeigt, dass in $\mathbb{R}^n$ $(n\geq 2)$ Partielle Differenzierbarkeit keine analoges  Approximationseigenschaften oder stetigkeit impliziert:
 \[f: \mathbb{R}^2 \to\mathbb{R} ,{\text{ }}f(x,y) = \left\{ {\begin{array}{*{20}{c}}
 {\frac{{xy}}{{{x^2} + {y^2}}}}&{(x,y)\not  = (0,0)}\\
 0&{(x,y)\not  = (0,0)}
@@ -147,12 +147,12 @@ Im Ursprung besitzt $f$ beide partielle Ableitungen, sie ist aber nicht stetig. 
 
 Die Lösung dieses Problem ist, dass man eine Approximations-Eigenschaft durch eine Lineare Abbildung postuliert. \\
 
-Sei $f:\mathbb{R}\rightarrow\mathbb{R}$ differenzierbar in $x_0;f'(x_0)$ existiert. In diesem Fall kann $f$ für alle $x$ nähe $x_0$ durch die Funktion $f(x_0)+f'(x_0)(x-x_0)$ gut approximiert werden. Dass heisst dass \[f(x)=f(x_0)+f'(x_0)(x-x_0)+R(x,x_0)\text{ \hspace{2mm}mit  }\mathop {\lim }\limits_{x \to {x_0}} \frac{{R(x,{x_0})}}{{x - {x_0}}} = 0\]
+Sei $f:\mathbb{R}\to\mathbb{R}$ differenzierbar in $x_0;f'(x_0)$ existiert. In diesem Fall kann $f$ für alle $x$ nähe $x_0$ durch die Funktion $f(x_0)+f'(x_0)(x-x_0)$ gut approximiert werden. Dass heisst dass \[f(x)=f(x_0)+f'(x_0)(x-x_0)+R(x,x_0)\text{ \hspace{2mm}mit  }\mathop {\lim }\limits_{x \to {x_0}} \frac{{R(x,{x_0})}}{{x - {x_0}}} = 0\]
 
 \subsubsection*{Bemerkung}
-$f'(x):\mathbb{R}\rightarrow\mathbb{R}'$ sollt als lineare Abbildung interpretiert werden
+$f'(x):\mathbb{R}\to\mathbb{R}'$ sollt als lineare Abbildung interpretiert werden
 \subsection*{Lineare Abbildungen}
-Eine Abbildung $A:\mathbb{R}^n\rightarrow\mathbb{R}$ ist linear falls für alle $x,y\in\mathbb{R}^n$ und $\alpha,\beta\in\mathbb{R}$ \[A\left( \alpha x+\beta y\right) =\alpha A(x)+\beta A(y)\]
+Eine Abbildung $A:\mathbb{R}^n\to\mathbb{R}$ ist linear falls für alle $x,y\in\mathbb{R}^n$ und $\alpha,\beta\in\mathbb{R}$ \[A\left( \alpha x+\beta y\right) =\alpha A(x)+\beta A(y)\]
 Eine solche Abbildung ist durch ihre Werte \[A(e_i):=A_1,A(e_2):=A_2,\dots,A(e_n):=A_n\] auf der Standardbasis $e_1,\dots,e_n$ eindeutig bestimmt. Aus $x = \sum\limits_{i = 1}^n {{x^i}{e_i}} $ und linearität folgt nämlich
 
 \[
@@ -165,33 +165,33 @@ Schreiben wir $x = \left( {\begin{array}{*{20}{c}}
  \vdots \\
 {{x^n}}
 \end{array}} \right)$ für einen Vektor $x = {({x^1})_{1 \le i \le n}}$ und \\ %break needed to have everything on the same line
-$A=\left( A_1,\dots,A_n\right)$ für die Darstellung einer Lineare Abbildung $A:\mathbb{R}^n\rightarrow\mathbb{R}$ bezüglich die Standard Basis $\left\{e_1,\dots,e_n\right\}$ so ist \[A(x) = \left( {{A_1}, \ldots ,{A_n}} \right)\left( {\begin{array}{*{20}{c}}
+$A=\left( A_1,\dots,A_n\right)$ für die Darstellung einer Lineare Abbildung $A:\mathbb{R}^n\to\mathbb{R}$ bezüglich die Standard Basis $\left\{e_1,\dots,e_n\right\}$ so ist \[A(x) = \left( {{A_1}, \ldots ,{A_n}} \right)\left( {\begin{array}{*{20}{c}}
 {{x^1}}\\
  \vdots \\
 {{x^n}}
 \end{array}} \right) = \sum {{A_i}{x^i}} \]
 
 \begin{definition}{8.4}
-Die Funktion $f:\Omega\rightarrow\mathbb{R}$ heisst an der Stelle $x_0\in\Omega\subset\mathbb{R}^n$ differenzierbar falls eine lineare Abbildung $A:\mathbb{R}^n\rightarrow\mathbb{R}$ gibt so dass \[f(x) = f\left( {{x_0}} \right) + A\left( {x - {x_0}} \right) + R\left( {{x_0},x} \right)\] wobei $\mathop {\lim }\limits_{x \to {x_0}} \frac{{R\left( {x,{x_0}} \right)}}{{\left| {x - {x_0}} \right|}} = 0$
+Die Funktion $f:\Omega\to\mathbb{R}$ heisst an der Stelle $x_0\in\Omega\subset\mathbb{R}^n$ differenzierbar falls eine lineare Abbildung $A:\mathbb{R}^n\to\mathbb{R}$ gibt so dass \[f(x) = f\left( {{x_0}} \right) + A\left( {x - {x_0}} \right) + R\left( {{x_0},x} \right)\] wobei $\mathop {\lim }\limits_{x \to {x_0}} \frac{{R\left( {x,{x_0}} \right)}}{{\left| {x - {x_0}} \right|}} = 0$
 \end{definition}
 In diesem fall heisst $A$ der Differential an der Stelle $x_0$ und wird mit $\mathop {df}\limits_{{x_0}} $ bezeichnet, d.h. $f$ ist total differenzierbar in $x_0=\left( x_0^1,\dots,x_0^n\right)$ falls reelle Zahlen $A_1,\dots,A_n$ existieren so dass gilt \[f(x) = f\left( {{x_0}} \right) + {A_1}\left( {{x^1} - x_0^1} \right) + {A_2}\left( {{x^2} - x_0^2} \right) +  \ldots  + {A_n}\left( {{x^n} - x_0^n} \right) + R\left( {x,{x_0}} \right)\] mit $\mathop {\lim }\limits_{x \to {x_0}} \frac{{R\left( {x,{x_0}} \right)}}{{\left| {x - {x_0}} \right|}} = 0$
 
 \subsubsection*{Bemerkung: Geometrische Interpretation}
-Sei $f:\Omega \rightarrow\mathbb{R}$, $\Omega\in\mathbb{R}^2$. Wir können die differenzierbare Funktion nähe dem Punkt $x_0=\left( x_0^1,x_0^2\right)$ mit hilfe der Lineare Funktion \[P\left( x \right) = P\left( {{x^1},{x^2}} \right) = f\left( {x_0^1,x_0^2} \right) + \underbrace {{A_1}\left( {{x^1} - x_0^1} \right) + {A_2}\left( {{x^2} - x_0^2} \right)}_{{d_x}_{_0}f\left( {x - {x_0}} \right)}\] approximieren. \\
+Sei $f:\Omega \to\mathbb{R}$, $\Omega\in\mathbb{R}^2$. Wir können die differenzierbare Funktion nähe dem Punkt $x_0=\left( x_0^1,x_0^2\right)$ mit hilfe der Lineare Funktion \[P\left( x \right) = P\left( {{x^1},{x^2}} \right) = f\left( {x_0^1,x_0^2} \right) + \underbrace {{A_1}\left( {{x^1} - x_0^1} \right) + {A_2}\left( {{x^2} - x_0^2} \right)}_{{d_x}_{_0}f\left( {x - {x_0}} \right)}\] approximieren. \\
 
 Die Differenz $\underbrace {f(x) - P(x)}_{{d_x}_{_0}f\left( {x - {x_0}} \right)}\mathop  \to \limits_{x \to {x_0}} 0$\todo{can't understand what comes after the formula, page 126.1 middle} $P(x)$ ist eine Ebene. Die ist die Tangenteebene zur $f$ an der Stelle $x_0$ und spielt die Rolle des Tangente für Funktionen in einer Variable. \missingfigure{page 126.1 bottom}
 
 \subsubsection*{Beispiel 8.5}
 \begin{enumerate}[\indent a)]
-\item Jede affin Lineare Funktion $f(x)=Ax+b$, $x\in\mathbb{R}^n$, wobei $a:\mathbb{R}^n\rightarrow\mathbb{R}$ linear, b$\in\mathbb{R}$ ist an jeder stelle $x_0\in\mathbb{R}^n$ differenzierbar, mit $\mathop {df}\limits_{{x_0}} =A$ unabhängig von $x_0$ da 
+\item Jede affin Lineare Funktion $f(x)=Ax+b$, $x\in\mathbb{R}^n$, wobei $a:\mathbb{R}^n\to\mathbb{R}$ linear, b$\in\mathbb{R}$ ist an jeder stelle $x_0\in\mathbb{R}^n$ differenzierbar, mit $\mathop {df}\limits_{{x_0}} =A$ unabhängig von $x_0$ da 
 \[f\left( x \right) - f\left( {{x_0}} \right) - A\left( {x - {x_0}} \right) = 0\hspace{10mm}\forall x,{x_0} \in\mathbb{R}^n\]
-\item Koordinaten funktionen $x^i:\mathbb{R}^n\rightarrow\mathbb{R}$, $\left( x^1,x^2,\dots,x^n\right)\rightarrow x^i$, $x^i(x)=x^i$. Dann ist $x^i$ differenzierbar an jeder Stelle $x_0\in\mathbb{R}^n$ mit \[{\left. {d{x^i}} \right|_{x = {x_0}}} = \left( {0, \ldots ,0,1,0, \ldots ,0} \right)\] die Differenziale $dx^1,dx^2,\dots,dx^n$ bilden also an jeder Stelle $x_0\in\mathbb{R}^n$ eine Basis des Raumes $L\left( {\mathbb{R}^n:\mathbb{R}} \right):=\left\{ A:\mathbb{R}^n\rightarrow\mathbb{R}; A\text{ linear}\right\}$, wobei wir $A\in L\left( \mathbb{R}^n:\mathbb{R}\right)$ mit der darstellung $A=\left( A_1,\dots,A_n\right)$ bzg. der Standardbasis $\{ e_1,\dots,e_n\}$ der $\mathbb{R}^n$ identifizieren, und mit $A_i=A\left( e_i\right)$ \[d{x^i} = \left( {0, \ldots ,0,1,0, \ldots ,0} \right)\]\[\left( {d{x^i}\left( {{e_1}} \right),d{x^i}\left( {{e_2}} \right), \ldots ,d{x^i}\left( {{e_n}} \right)} \right)\]
+\item Koordinaten funktionen $x^i:\mathbb{R}^n\to\mathbb{R}$, $\left( x^1,x^2,\dots,x^n\right)\to x^i$, $x^i(x)=x^i$. Dann ist $x^i$ differenzierbar an jeder Stelle $x_0\in\mathbb{R}^n$ mit \[{\left. {d{x^i}} \right|_{x = {x_0}}} = \left( {0, \ldots ,0,1,0, \ldots ,0} \right)\] die Differenziale $dx^1,dx^2,\dots,dx^n$ bilden also an jeder Stelle $x_0\in\mathbb{R}^n$ eine Basis des Raumes $L\left( {\mathbb{R}^n:\mathbb{R}} \right):=\left\{ A:\mathbb{R}^n\to\mathbb{R}; A\text{ linear}\right\}$, wobei wir $A\in L\left( \mathbb{R}^n:\mathbb{R}\right)$ mit der darstellung $A=\left( A_1,\dots,A_n\right)$ bzg. der Standardbasis $\{ e_1,\dots,e_n\}$ der $\mathbb{R}^n$ identifizieren, und mit $A_i=A\left( e_i\right)$ \[d{x^i} = \left( {0, \ldots ,0,1,0, \ldots ,0} \right)\]\[\left( {d{x^i}\left( {{e_1}} \right),d{x^i}\left( {{e_2}} \right), \ldots ,d{x^i}\left( {{e_n}} \right)} \right)\]
 Da gilt $d{x^i}\left( {{e_j}} \right) = \left\{ {\begin{array}{*{20}{c}}
 1&{i = j}\\
 0&{i\not  = j}
 \end{array}} \right.$ ist ${\left( {d{x^i}} \right)_{1 \le i \le n}}$ die duale Basis von $L\left( \mathbb{R}^n:\mathbb{R}\right)$ zur Standardbasis ${\left( {e_i} \right)_{1 \le i \le n}}$ des $\mathbb{R}^n$.
-\item Jedes $f:\mathbb{R}\rightarrow\mathbb{R}\in\subset '\left(\mathbb{R}\right)$ besitzt das Differential \[df\left( {{x_0}} \right) = \frac{{df}}{{dx}}\left( {{x_0}} \right)dx = f'\left( {{x_0}} \right)dx\] d.h. $f'\left(x_0\right)$ ist die Darstellung von $df\left(x_0\right)$ bezüglich der Basis $dx$ von $L\left(\mathbb{R}:\mathbb{R}\right)$ 
-\item $f\left(x,y\right)=xe^y$, $\mathbb{R}^2\rightarrow\mathbb{R}$ ist an jeder Stelle $\left(x_0,y_0\right)\in\mathbb{R}^2$ differenzierbar und es gilt \[df\left( {{x_0},{y_0}} \right) = \left( {\frac{{\partial f}}{{\partial x}}\left( {{x_0},{y_0}} \right),\frac{{\partial f}}{{\partial y}}\left( {{x_0},{y_0}} \right)} \right) = \left( {{e^{{y_0}}},x{e^{{y_0}}}} \right)\] \[f\left( {x,y} \right) - f\left( {{x_0},{y_0}} \right) = \underbrace {f\left( {x,y} \right) - f\left( {{x_0},y} \right)}_ \swarrow  + f\left( {{x_0},y} \right) - f\left( {{x_0},{y_0}} \right)\] \[ = \frac{{\partial f}}{{\partial x}}\left( {\xi ,y} \right)\left( {x - {x_0}} \right) + \frac{{\partial f}}{{\partial y}}\left( {{x_0},\eta } \right)\left( {y - {y_0}} \right)\]
+\item Jedes $f:\mathbb{R}\to\mathbb{R}\in\subset '\left(\mathbb{R}\right)$ besitzt das Differential \[df\left( {{x_0}} \right) = \frac{{df}}{{dx}}\left( {{x_0}} \right)dx = f'\left( {{x_0}} \right)dx\] d.h. $f'\left(x_0\right)$ ist die Darstellung von $df\left(x_0\right)$ bezüglich der Basis $dx$ von $L\left(\mathbb{R}:\mathbb{R}\right)$ 
+\item $f\left(x,y\right)=xe^y$, $\mathbb{R}^2\to\mathbb{R}$ ist an jeder Stelle $\left(x_0,y_0\right)\in\mathbb{R}^2$ differenzierbar und es gilt \[df\left( {{x_0},{y_0}} \right) = \left( {\frac{{\partial f}}{{\partial x}}\left( {{x_0},{y_0}} \right),\frac{{\partial f}}{{\partial y}}\left( {{x_0},{y_0}} \right)} \right) = \left( {{e^{{y_0}}},x{e^{{y_0}}}} \right)\] \[f\left( {x,y} \right) - f\left( {{x_0},{y_0}} \right) = \underbrace {f\left( {x,y} \right) - f\left( {{x_0},y} \right)}_ \swarrow  + f\left( {{x_0},y} \right) - f\left( {{x_0},{y_0}} \right)\] \[ = \frac{{\partial f}}{{\partial x}}\left( {\xi ,y} \right)\left( {x - {x_0}} \right) + \frac{{\partial f}}{{\partial y}}\left( {{x_0},\eta } \right)\left( {y - {y_0}} \right)\]
 Nach der MWS der DR, mit geeigneten Zwischenstellen $\xi=\xi (y)$ und $\eta$ \[ = \frac{{\partial f}}{{\partial x}}\left( {{x_0},{y_0}} \right)\left( {x - {x_0}} \right) + \frac{{\partial f}}{{\partial y}}\left( {{x_0},{y_0}} \right)\left( {y - {y_0}} \right) + R\left( {x,y} \right)\] 
 mit
 \begin{align*}
@@ -202,7 +202,7 @@ Wegen die Stetigkeit der Funktionen \[\frac{{\partial f}}{{\partial x}}\left( {x
 {\left| {\xi  - {x_0}} \right| < \left| {x - {x_0}} \right|}\\
 {\left| {\eta  - {y_0}} \right| < \left| {y - {y_0}} \right|}
 \end{array}} \left( {\left| {{e^y} - {e^{{y_0}}}} \right| + \left| {{x_0}} \right|\left| {{e^\eta } - {e^{{y_0}}}} \right|} \right)\]
-Für $\left( x,y\right)\rightarrow\left( x_0,y_0\right)$, $\left( x,y\right)\not=\left( x_0,y_0\right)$: d.h. es gilt \[\frac{{R\left( {x,y} \right)}}{{\left| {\left( {x,y} \right) - \left( {{x_0},{y_0}} \right)} \right|}} \to 0\] 
+Für $\left( x,y\right)\to\left( x_0,y_0\right)$, $\left( x,y\right)\not=\left( x_0,y_0\right)$: d.h. es gilt \[\frac{{R\left( {x,y} \right)}}{{\left| {\left( {x,y} \right) - \left( {{x_0},{y_0}} \right)} \right|}} \to 0\] 
 d.h. es gilt \[\frac{{f\left( {x,y} \right) - f\left( {{x_0},{y_0}} \right) - \frac{{\partial f}}{{\partial x}}\left( {{x_0},{y_0}} \right)\left( {x - {x_0}} \right) - \frac{{\partial f}}{{\partial y}}\left( {{x_0},{y_0}} \right)\left( {y - {y_0}} \right)}}{{\left| {\left( {x,y} \right) - \left( {{x_0},{y_0}} \right)} \right|}}\mathop  \to \limits_{\left( {x,y} \right) \to \left( {{x_0},{y_0}} \right)} 0\]
  d.h. $f\left( x,y\right)$ ist \todo{can't read, page 130 bottom} differenzierbar und 
 \[df\left( {{x_0},{y_0}} \right) = \left( {\frac{{\partial f}}{{\partial x}}\left( {{x_0},{y_0}} \right),\frac{{\partial f}}{{\partial y}}\left( {{x_0},{y_0}} \right)} \right)\]
@@ -222,7 +222,7 @@ Mittels Polarkoordinaten ist dies noch einsichtiger
 
 \subsubsection*{Bemerkung 8.6}
 
-Sei $f:\Omega\rightarrow\mathbb{R}$, $\Omega\subset\mathbb{R}^n$ differenzierbar an der Stelle $x_0\in\Omega$. Dann existieren die partiellen Ableitungen $\frac{\partial f}{\partial x^i}\left( x_0\right)$, $i=1,\dots,n$ und dass Differential kann \[{d_{{y_0}}}f = \left( {\frac{{\partial f}}{{\partial {x^1}}}\left( {{x_0}} \right), \ldots ,\frac{{\partial f}}{{\partial {x^n}}}\left( {{x_0}} \right)} \right)\] dargestellt werden. 
+Sei $f:\Omega\to\mathbb{R}$, $\Omega\subset\mathbb{R}^n$ differenzierbar an der Stelle $x_0\in\Omega$. Dann existieren die partiellen Ableitungen $\frac{\partial f}{\partial x^i}\left( x_0\right)$, $i=1,\dots,n$ und dass Differential kann \[{d_{{y_0}}}f = \left( {\frac{{\partial f}}{{\partial {x^1}}}\left( {{x_0}} \right), \ldots ,\frac{{\partial f}}{{\partial {x^n}}}\left( {{x_0}} \right)} \right)\] dargestellt werden. 
 
 \subsubsection*{Beweis}
 $f$ an der Stelle $x_0$ differenzierbar \[\Rightarrow f\left( {{x_0} + h{e_i}} \right) = f\left( {{x_0}} \right) + \left( {{d_{{x_0}}}f} \right)\left( {h{e_i}} \right) + R\left( {{x_0} + h{e_i},{x_0}} \right)\] wobei \[\mathop {\lim }\limits_{h \to 0} \frac{{R\left( {{x_0} + h{e_i},{x_0}} \right)}}{h} = \lim \frac{{f\left( {{x_0} + h{e_i}} \right) - f\left( {{x_0}} \right)\left( {{d_{{x_0}}}f\left( {h{e_i}} \right)} \right)}}{h} = 0\] \[ \Rightarrow \lim \frac{{f\left( {{x_0} + h{e_i}} \right) - f\left( {{x_0}} \right)}}{h} = \lim \frac{{h{d_{{x_0}}}f\left( {{e_i}} \right)}}{h} = {d_{{x_0}}}f\left( {{e_i}} \right)\] d.h. $\frac{\partial f}{\partial x^i}\left( x_0\right)$ existiert und $=d_{x_0}f\left( e_i\right)$. \\
@@ -236,12 +236,12 @@ Die Funktion \[f\left( {x,y} \right) = \left\{ {\begin{array}{*{20}{c}}
 \end{array}} \right.\] ist in $\left( 0,0\right)$ nicht differenzierbar ($f$ ist  in $\left( 0,0\right)$ nicht stetig)
 
 \subsubsection*{Satz 8.7}
-Falls $f:\Omega\rightarrow\mathbb{R}$ in $x_0\in\Omega\subset\mathbb{R}$ differenzierbar, ist sie in $x_0$ auch stetig.
+Falls $f:\Omega\to\mathbb{R}$ in $x_0\in\Omega\subset\mathbb{R}$ differenzierbar, ist sie in $x_0$ auch stetig.
 
 \subsubsection*{Beweis}
 Folgt aus der Definition
 \begin{definition}{8.8}
-$f:\Omega\rightarrow\mathbb{R}$ heisst von der Klasse $C'$, $\left( f\in C'\left(\Omega\right)\right)$ falls $f$ an jeder Stelle $x_0\in\Omega$ und in jede Richtung $e_i$ partielle differenzierbar ist und die Funktionen $x\rightarrow\frac{\partial f}{\partial x^i}\left(x\right)$ für jedes $1\leq i\leq n$ auf $\Omega$ stetig sind
+$f:\Omega\to\mathbb{R}$ heisst von der Klasse $C'$, $\left( f\in C'\left(\Omega\right)\right)$ falls $f$ an jeder Stelle $x_0\in\Omega$ und in jede Richtung $e_i$ partielle differenzierbar ist und die Funktionen $x\to\frac{\partial f}{\partial x^i}\left(x\right)$ für jedes $1\leq i\leq n$ auf $\Omega$ stetig sind
 \end{definition}
 \subsubsection*{Satz 8.9}
 Sei $f\in C'\left(\Omega\right)$. Dann ist $f$ an jeder Stelle $x_0\in\Omega$ differenzierbar. 
@@ -282,7 +282,7 @@ Polynome auf $\mathbb{R}^n$ sind von Klasse $C!$. Für jedes Multindex $\alpha=\
 Ganz analog zum eindimensionalen Fall gelten folgende Differentiationsregeln
 
 \subsubsection*{Satz 8.11}
-Sei $\Omega\subset\mathbb{R}^n$, sowie $f,g:\Omega\rightarrow\mathbb{R}$ an der Stelle $x_0\in\Omega$ differenzierbar. Dann gilt \begin{enumerate}
+Sei $\Omega\subset\mathbb{R}^n$, sowie $f,g:\Omega\to\mathbb{R}$ an der Stelle $x_0\in\Omega$ differenzierbar. Dann gilt \begin{enumerate}
 \item $d\left( {f + g} \right)\left( {{x_0}} \right) = df\left( {{x_0}} \right) + dg\left( {{x_0}} \right)$
 \item $d\left( {fg} \right)\left( {{x_0}} \right) = g\left( {{x_0}} \right)df\left( {{x_0}} \right) + f\left( {{x_0}} \right)dg\left( {{x_0}} \right)$
 \item Falls $g\left( x_0\right)\not=0$ \[d\left( {\frac{f}{g}} \right)\left( {{x_0}} \right) = \frac{{g\left( {{x_0}} \right)df\left( {{x_0}} \right) - f\left( {{x_0}} \right)dg\left( {{x_0}} \right)}}{{{{\left( {g\left( {{x_0}} \right)} \right)}^2}}}\]
@@ -290,7 +290,7 @@ Sei $\Omega\subset\mathbb{R}^n$, sowie $f,g:\Omega\rightarrow\mathbb{R}$ an der 
 Beweis ist der selbe wie in Dim=1. Für die Kettenregel gibt es mehrere variationen 
 
 \subsubsection*{Satz 8.12 (Kettenregel, 1. Version)}
-Sei $g:\Omega\rightarrow\mathbb{R}$ in $x_0\in\Omega\subset\mathbb{R}^n$ differenzierbar, sowie $f\mathbb{R}\rightarrow\mathbb{R}$ an der stelle $g\left( x_0\right)\in\mathbb{R}$ differenzierbar. Dann gilt \[d\left( {f \circ g} \right)\left( {{x_0}} \right) = f'\left( {g\left( {{x_0}} \right)} \right) \cdot dg\left( {{x_0}} \right)\]
+Sei $g:\Omega\to\mathbb{R}$ in $x_0\in\Omega\subset\mathbb{R}^n$ differenzierbar, sowie $f\mathbb{R}\to\mathbb{R}$ an der stelle $g\left( x_0\right)\in\mathbb{R}$ differenzierbar. Dann gilt \[d\left( {f \circ g} \right)\left( {{x_0}} \right) = f'\left( {g\left( {{x_0}} \right)} \right) \cdot dg\left( {{x_0}} \right)\]
 
 \missingfigure{page 137, middle UPDATE:STARTED DRAWING, MISSING DIAGRAM ON LEFT SIDE}
 
@@ -344,19 +344,19 @@ und
 \[\frac{{{R_{f \circ g}}\left( {x,{x_0}} \right)}}{{x - {x_0}}} = \underbrace {f'\left( {g\left( {{x_0}} \right)} \right)\frac{{{R_g}\left( {x,{x_0}} \right)}}{{\left( {x - {x_0}} \right)}}}_{ \downarrow 0} + \underbrace {\frac{{{R_f}\left( {g\left( {{x_0}} \right),g\left( x \right)} \right)}}{{x - {x_0}}}}_{ \downarrow 0}\]
 
 \subsubsection*{Beispiel 8.13}
-Sei $h:\mathbb{R}^2\rightarrow\mathbb{R}$ \[h(x,y)=e^{xy}\] $h= f\circ g$ wobei $g(x,y)=xy$, $f(t)=e^t$. Dann ist einerseits \[dh\left( {x,y} \right) = \left( {\frac{{\partial h}}{{\partial x}},\frac{{\partial h}}{{\partial y}}} \right) = \left( {y{e^{xy}},x{e^{xy}}} \right)\] anderseits nach Kettenregel 
+Sei $h:\mathbb{R}^2\to\mathbb{R}$ \[h(x,y)=e^{xy}\] $h= f\circ g$ wobei $g(x,y)=xy$, $f(t)=e^t$. Dann ist einerseits \[dh\left( {x,y} \right) = \left( {\frac{{\partial h}}{{\partial x}},\frac{{\partial h}}{{\partial y}}} \right) = \left( {y{e^{xy}},x{e^{xy}}} \right)\] anderseits nach Kettenregel 
 \[dh\left( {x,y} \right) = d\left( {f \circ g} \right)' = f'\left( {g\left( {x,y} \right)} \right) \cdot dg\left( {x,y} \right) = {e^{xy}} \cdot \left( {y,x} \right) = \left( {y{e^{xy}},x{e^{xy}}} \right)\]
 Für die nächste Kettenregel führen wir folgende Definition ein:
 
 \begin{definition}{8.14}
-Sei $\Omega \subset\mathbb{R}$ und $f=\left( f_1,\dots,f_n\right):\Omega\rightarrow\mathbb{R}^n$ eine Abbildung. Dann ist $f$ an der Stelle $x_0\in\mathbb{R}$ differenzierbar, falls jede Komponentenfunktion $f_i$ an der Stelle $x_0$ differenzierbar ist. Wir definieren in diesem Fall \[f'\left( {{x_0}} \right): = \left( {{f_1}'\left( {{x_0}} \right),{f_2}'\left( {{x_0}} \right), \ldots ,{f_n}'\left( {{x_0}} \right)} \right)\]
+Sei $\Omega \subset\mathbb{R}$ und $f=\left( f_1,\dots,f_n\right):\Omega\to\mathbb{R}^n$ eine Abbildung. Dann ist $f$ an der Stelle $x_0\in\mathbb{R}$ differenzierbar, falls jede Komponentenfunktion $f_i$ an der Stelle $x_0$ differenzierbar ist. Wir definieren in diesem Fall \[f'\left( {{x_0}} \right): = \left( {{f_1}'\left( {{x_0}} \right),{f_2}'\left( {{x_0}} \right), \ldots ,{f_n}'\left( {{x_0}} \right)} \right)\]
 \end{definition}
 
 \subsubsection*{Bemerkung 8.15}
 $f'\left( x_0\right)$ kann als Geschwindigkeitsvektor im Punkt $f\left( x_0\right)$ aufgefasst werden.
 
 \subsubsection*{Satz 8.16 (Kettenregel, 2. Version)}
-Sei $\Omega\subset\mathbb{R}^n$,$I\subset\mathbb{R}$. Sei $g:I\rightarrow\Omega$, $t\rightarrow\left( g_1(t), g_2(t),\dots, g_n(t)\right)$, an der Stelle $t_0\in I$ differenzierbar sowie $f:\Omega\rightarrow\mathbb{R}$ an der Stelle $g\left( t_0\right)$ differenzierbar. Dann gilt:
+Sei $\Omega\subset\mathbb{R}^n$,$I\subset\mathbb{R}$. Sei $g:I\to\Omega$, $t\to\left( g_1(t), g_2(t),\dots, g_n(t)\right)$, an der Stelle $t_0\in I$ differenzierbar sowie $f:\Omega\to\mathbb{R}$ an der Stelle $g\left( t_0\right)$ differenzierbar. Dann gilt:
 \[\frac{d}{{dt}}\left( {f \circ g} \right)\left( {{t_0}} \right) = df\left( {g\left( {{t_0}} \right)} \right) \cdot g'\left( {{t_0}} \right)\]
 \begin{align*}
 d\left( {f \circ g} \right)\left( {{t_0}} \right) = &df\left( {g\left( {{t_0}} \right)} \right) \cdot dg\left( {{t_0}} \right)\\
@@ -367,11 +367,11 @@ d\left( {f \circ g} \right)\left( {{t_0}} \right) = &df\left( {g\left( {{t_0}} \
 \subsubsection*{Beispiel 8.17}
 Die vier Grundrechenarten sind differenzierbare Funktionen von zwei variablen. Insbesondere gilt: 
 \begin{itemize}
-\item $a:\mathbb{R}^2\rightarrow\mathbb{R}$, $\left( x,y\right) \rightarrow x+y$ \[da\left( {x,y} \right) = \left( {\frac{{\partial a}}{{\partial x}},\frac{{\partial a}}{{\partial y}}} \right) = \left( {1,1} \right)\]
-\item $m:\mathbb{R}^2\rightarrow \mathbb{R}$, $\left( x,y\right) \rightarrow x\cdot y$ \[dm\left( {x,y} \right) = \left( {y,x} \right)\]
+\item $a:\mathbb{R}^2\to\mathbb{R}$, $\left( x,y\right) \to x+y$ \[da\left( {x,y} \right) = \left( {\frac{{\partial a}}{{\partial x}},\frac{{\partial a}}{{\partial y}}} \right) = \left( {1,1} \right)\]
+\item $m:\mathbb{R}^2\to \mathbb{R}$, $\left( x,y\right) \to x\cdot y$ \[dm\left( {x,y} \right) = \left( {y,x} \right)\]
 \end{itemize}
 Setzt man diese beiden Funktionen in die obige Kettenregel ein, so erhält man die aus der Analysis I bekannte Summen und Produktregel: 
-\[g:\mathbb{R}\rightarrow\mathbb{R}^2, t\rightarrow \left( g_1(t),g_2(t)\right)\]
+\[g:\mathbb{R}\to\mathbb{R}^2, t\to \left( g_1(t),g_2(t)\right)\]
 \[\frac{d}{{dt}}\left( {{g_1} + {g_2}} \right) = \frac{d}{{dt}}\left( {a \circ g} \right) = \left( {1,1} \right) \cdot \left( {\frac{{d{g_1}}}{{dt}},\frac{{d{g_2}}}{{dt}}} \right) = 1\cdot \frac{{d{g_1}}}{{dt}} + 1\cdot \frac{{d{g_2}}}{{dt}}\]
 und 
 \begin{align*}
@@ -381,7 +381,7 @@ und
 \end{align*}
 
 \subsubsection*{Beispiel 8.18}
-Sei $f:\Omega\rightarrow\mathbb{R}$ differenzierbar an der Stelle $x_0\in\Omega$ und sei $e\in\mathbb{R}^n\backslash\{ 0\}$; mit $\left| e\right|=1$. Betrachte die Gerade $g(t)=x_0+te$, $t\in\mathbb{R}$ durch $x_0$ mit Richtungsvektor 
+Sei $f:\Omega\to\mathbb{R}$ differenzierbar an der Stelle $x_0\in\Omega$ und sei $e\in\mathbb{R}^n\backslash\{ 0\}$; mit $\left| e\right|=1$. Betrachte die Gerade $g(t)=x_0+te$, $t\in\mathbb{R}$ durch $x_0$ mit Richtungsvektor 
 
 \begin{figure}[H]
 \begin{minipage}[b]{0.45\linewidth}
@@ -410,8 +410,8 @@ Sei $f:\Omega\rightarrow\mathbb{R}$ differenzierbar an der Stelle $x_0\in\Omega$
 \centering
 \[\frac{dg}{dt}\left( t_0\right)=\mathbb{R}\hspace{5mm}\forall t_0\in\mathbb{R}\]
 \begin{align*}
-g:\mathbb{R}&\rightarrow\mathbb{R}^2\\
-t&\rightarrow x_0+te
+g:\mathbb{R}&\to\mathbb{R}^2\\
+t&\to x_0+te
 \end{align*}
 
 \end{minipage}
@@ -430,27 +430,27 @@ Eine Menge $K\subset \mathbb{R}^n$ ist genau dann Konvex falls für jede Paar vo
 \missingfigure{Page 145, middle}
 \end{definition}
 \subsubsection*{Satz 8.20}
-Sei $\Omega\subset\mathbb{R}^n$ konvex $f:\Omega\rightarrow\mathbb{R}$ differenzierbar, $x_0,x_1\in\Omega$ sowie $x_t:=\left( 1-t\right) x_0+tx_1$\todo{is it $tx_1$ or $tx$, ?? page 145 middle}. Dann gibt es $\vartheta\in\lbrack 0,1\rbrack$ mit \[f\left( {{x_1}} \right) - f\left( {{x_0}} \right) = df\left( {{x_{i\vartheta }}} \right)\left( {{x_1} - {x_0}} \right)\]
+Sei $\Omega\subset\mathbb{R}^n$ konvex $f:\Omega\to\mathbb{R}$ differenzierbar, $x_0,x_1\in\Omega$ sowie $x_t:=\left( 1-t\right) x_0+tx_1$\todo{is it $tx_1$ or $tx$, ?? page 145 middle}. Dann gibt es $\vartheta\in\lbrack 0,1\rbrack$ mit \[f\left( {{x_1}} \right) - f\left( {{x_0}} \right) = df\left( {{x_{i\vartheta }}} \right)\left( {{x_1} - {x_0}} \right)\]
 
 \subsubsection*{Beweis}
-Sei $g\left( t\right) = \left( 1-t\right) x_0+tx_1=x_t$. Dann ist $t\rightarrow \left( f\circ g\right)(t)$ auf $\left[ 0,1\right]$ stetig und in $\left( 0,1\right)$ differenzierbar. Also gibt es $\vartheta\in\left( 0,1\right)$ mit (nach MWS der DS einer variable) \[f\left( {{x_i}} \right) - f\left( {{x_0}} \right) = \left( {f \circ g} \right)(1) - \left( {f \circ g} \right)(0) = \left( {f \circ g} \right)'\left( \vartheta  \right)\left( {1 - 0} \right)\] Nur ist \[\left( {f \circ g} \right)'\left( \vartheta  \right) = df\left( {g\left( \vartheta  \right) \cdot \frac{{dg}}{{dt}}\left( \vartheta  \right)} \right)\] \todo{Is the formula done or does it continue on a new line, page 146 top}
+Sei $g\left( t\right) = \left( 1-t\right) x_0+tx_1=x_t$. Dann ist $t\to \left( f\circ g\right)(t)$ auf $\left[ 0,1\right]$ stetig und in $\left( 0,1\right)$ differenzierbar. Also gibt es $\vartheta\in\left( 0,1\right)$ mit (nach MWS der DS einer variable) \[f\left( {{x_i}} \right) - f\left( {{x_0}} \right) = \left( {f \circ g} \right)(1) - \left( {f \circ g} \right)(0) = \left( {f \circ g} \right)'\left( \vartheta  \right)\left( {1 - 0} \right)\] Nur ist \[\left( {f \circ g} \right)'\left( \vartheta  \right) = df\left( {g\left( \vartheta  \right) \cdot \frac{{dg}}{{dt}}\left( \vartheta  \right)} \right)\] \todo{Is the formula done or does it continue on a new line, page 146 top}
 %\[\left( {df} \right)\left( {{x_\vartheta }} \right)\left( { - {x_0} + {x_1}} \right)\]
 Die Kettenregel wird auch angewandelt um Integrale mit Parametern zu studieren. Ein Beispiel davon ist:
 
 \subsubsection*{Beispiel}
-Sei $h:\mathbb{R}^2\rightarrow\mathbb{R}$, $\left( s,t\right)\rightarrow h\left(s,t \right)$. Wir nehmen an, $h$ ist stetig, $\frac{\partial h}{\partial t}$ existiert und ist uf ganz $\mathbb{R}^2$ stetig. Sei 
+Sei $h:\mathbb{R}^2\to\mathbb{R}$, $\left( s,t\right)\to h\left(s,t \right)$. Wir nehmen an, $h$ ist stetig, $\frac{\partial h}{\partial t}$ existiert und ist uf ganz $\mathbb{R}^2$ stetig. Sei 
 \[u(t) = \int\limits_a^{b(t)} {h(s,t)ds} {\text{, }}b(t) \in\subset '\left( \mathbb{R} \right){\text{, }}a \in\mathbb{R}\]\todo{Is it $C'$ or $\subset '$?? page 146 middle}
 
 \subsubsection*{Satz 8.21}
 Sei $h(s,t)$ eine stetige differenzierbare Funktion von zwei variablen und $b(t)$ differenzierbare Funktion eine variable. Dann ist die Funktion \[u(t): = \int\limits_a^{b(t)} {h(s,t)ds} \] wo definiert, differenzierbar mit der Ableitung \[u'(t): = h\left( {b(t),t} \right) \cdot b'(t) + \int\limits_a^{b(t)} {\frac{{\partial h}}{{\partial t}}\left( {s,t} \right)ds} \]
 \subsubsection*{Korollar 8.22}
-Sei $h=h\left( s,t\right) :\mathbb{R}^2\rightarrow\mathbb{R}$ stetig, und $\frac{\partial h}{\partial t}$ existiert und auf ganz $\mathbb{R}^2$ stetig. Sei \[u(t) = \int\limits_0^t {h\left( {s,t} \right)ds} \] Dann \[u(t) \in  \subset '\left( \mathbb{R}\right)\text{ und }u'(t) = h\left( {t,t} \right) + \int\limits_0^t {\frac{{\partial h}}{{\partial t}}\left( {s,t} \right)ds} \]
+Sei $h=h\left( s,t\right) :\mathbb{R}^2\to\mathbb{R}$ stetig, und $\frac{\partial h}{\partial t}$ existiert und auf ganz $\mathbb{R}^2$ stetig. Sei \[u(t) = \int\limits_0^t {h\left( {s,t} \right)ds} \] Dann \[u(t) \in  \subset '\left( \mathbb{R}\right)\text{ und }u'(t) = h\left( {t,t} \right) + \int\limits_0^t {\frac{{\partial h}}{{\partial t}}\left( {s,t} \right)ds} \]
 
 \subsubsection*{Beweis}
 Setze $b(t)=t$, $a=0$ in Satz 8.21.
 
 \subsubsection*{Korollar 8.23}
-Sei $h:\mathbb{R}^2\rightarrow\mathbb{R}$ eine stetige Funktion mit Stetiger partieller Ableitung $\frac{\partial h}{\partial t}$. Dann ist die Funktion \[u(t): = \int\limits_a^b {h(s,t)ds} \] differenzierbar mit Ableitung \[u'(t): = \int\limits_a^b {\frac{{\partial h}}{{\partial t}}(s,t)ds} \] 
+Sei $h:\mathbb{R}^2\to\mathbb{R}$ eine stetige Funktion mit Stetiger partieller Ableitung $\frac{\partial h}{\partial t}$. Dann ist die Funktion \[u(t): = \int\limits_a^b {h(s,t)ds} \] differenzierbar mit Ableitung \[u'(t): = \int\limits_a^b {\frac{{\partial h}}{{\partial t}}(s,t)ds} \] 
 
 \subsubsection*{Beweis}
 Setze $b(t)=b$, in Satz 8.20
@@ -466,11 +466,11 @@ Für eine noch zu bestimmende Konstante $C$. Aber
 \[ \Rightarrow \int\limits_0^1 {\frac{{{x^5} - 1}}{{\log x}}dx = \log 6} \]
 
 \subsubsection*{Beweis Satz 8.21 (Idee)}
-Sei \[f\left( {x,y} \right) = \int\limits_a^x {h\left( {s,y} \right)ds}:\mathbb{R}^2\rightarrow\mathbb{R} \]
+Sei \[f\left( {x,y} \right) = \int\limits_a^x {h\left( {s,y} \right)ds}:\mathbb{R}^2\to\mathbb{R} \]
 \[g\left( t \right) = \left( {\begin{array}{*{20}{c}}
 {b\left( t \right)}\\
 t
-\end{array}} \right):\mathbb{R}\rightarrow\mathbb{R}^2\text{, }g'\left( t \right) = \left( {\begin{array}{*{20}{c}}
+\end{array}} \right):\mathbb{R}\to\mathbb{R}^2\text{, }g'\left( t \right) = \left( {\begin{array}{*{20}{c}}
 {b'\left( t \right)}\\
 1
 \end{array}} \right)\]
@@ -490,27 +490,27 @@ u'(t) = &\frac{d}{{dt}}\left( {f \circ g} \right)(t) = \left( {\frac{{\partial f
 = & h\left( {b(t),t} \right) \cdot b'(t) + \int\limits_a^{b(t)} {\frac{{\partial h}}{{\partial t}}(s,t)ds}
 \end{align*}
 \section{Differentialformen und Vektorfelder}
-Sei $L\left(\mathbb{R}^n,\mathbb{R}\right)$ der Raum der linearen Abbildungen von $\mathbb{R}^n$ nach $\mathbb{R}$. Falls $f:\Omega\subset\mathbb{R}^n\rightarrow\mathbb{R}$ eine Funktion ist, die in jedem Punkt differenzierbar ist, dann ist $df(x)\in L\left(\mathbb{R}^n,\mathbb{R}\right)$ und man erhält eine Abbildung
+Sei $L\left(\mathbb{R}^n,\mathbb{R}\right)$ der Raum der linearen Abbildungen von $\mathbb{R}^n$ nach $\mathbb{R}$. Falls $f:\Omega\subset\mathbb{R}^n\to\mathbb{R}$ eine Funktion ist, die in jedem Punkt differenzierbar ist, dann ist $df(x)\in L\left(\mathbb{R}^n,\mathbb{R}\right)$ und man erhält eine Abbildung
 \begin{align*}
-\Omega &\rightarrow L\left(\mathbb{R}^n,\mathbb{R}\right)\\
-x_0 &\rightarrow df\left(x_0\right) = \left( {\frac{{\partial f}}{{\partial {x^1}}}\left( {{x_0}} \right), \ldots ,\frac{{\partial f}}{{\partial {x^n}}}\left( {{x_0}} \right)} \right)\\
+\Omega &\to L\left(\mathbb{R}^n,\mathbb{R}\right)\\
+x_0 &\to df\left(x_0\right) = \left( {\frac{{\partial f}}{{\partial {x^1}}}\left( {{x_0}} \right), \ldots ,\frac{{\partial f}}{{\partial {x^n}}}\left( {{x_0}} \right)} \right)\\
 & \hspace{16mm}=  \frac{{\partial f}}{{\partial {x^1}}}\left( {{x_0}} \right)d{x^1} +  \ldots  + \frac{{\partial f}}{{\partial {x^n}}}\left( {{x_0}} \right)d{x^n}
 \end{align*}
 Dies ist ein Beispiel von $1-$form
 
 \begin{definition}{8.26}
-Eine Differentialform vom Grad 1 (auch ``$1-$Form'') auf $\Omega$ ist eine Abbildung \[\lambda :\Omega\rightarrow L\left(\mathbb{R}^n,\mathbb{R}\right)\]
+Eine Differentialform vom Grad 1 (auch ``$1-$Form'') auf $\Omega$ ist eine Abbildung \[\lambda :\Omega\to L\left(\mathbb{R}^n,\mathbb{R}\right)\]
 \end{definition}
 \subsubsection*{Beispiel 8.27}
 \begin{enumerate}
-\item Seien $x^i:\mathbb{R}^n\rightarrow\mathbb{R}$ die Koordinatenfunktionen $1\leq i\leq n$. Für jedes $x_0\in\mathbb{R}^n$ ist $dx^i\left(x_0\right)\in L\left( \mathbb{R}^n,\mathbb{R}\right)$; dies führt zur $1-$Form
+\item Seien $x^i:\mathbb{R}^n\to\mathbb{R}$ die Koordinatenfunktionen $1\leq i\leq n$. Für jedes $x_0\in\mathbb{R}^n$ ist $dx^i\left(x_0\right)\in L\left( \mathbb{R}^n,\mathbb{R}\right)$; dies führt zur $1-$Form
 \begin{align*}
-dx^i:\mathbb{R}^n&\rightarrow L\left( \mathbb{R}^n,\mathbb{R}\right)\\
-x_0 &\rightarrow dx^i\left( x_0\right)
+dx^i:\mathbb{R}^n&\to L\left( \mathbb{R}^n,\mathbb{R}\right)\\
+x_0 &\to dx^i\left( x_0\right)
 \end{align*}
 Für jedes $x_0\in\mathbb{R}^n$, gilt $dx^i\left(e_j\right)=\delta_{ij}$ also bilden $dx^1\left( x_0\right),\dots,dx^n\left( x_0\right)$ eine Basis für $L\left(\mathbb{R}^n,\mathbb{R}\right)$, $\forall x\in\mathbb{R}^n$.\\
 
-Eine beliebig $1-$Form $\lambda :\mathbb{R}^n\rightarrow L\left(\mathbb{R}^n,\mathbb{R}\right)$ lässt sich dann eindeutig wie folgt darstellen \[\lambda \left( {{x_0}} \right) = \sum\limits_{i = 1}^n {{\lambda _i}\left( {{x_0}} \right)d{x^i}\left( {{x_0}} \right)} \] wobei $\lambda_i:\mathbb{R}^n\rightarrow\mathbb{R}$ Funktionen sind.
+Eine beliebig $1-$Form $\lambda :\mathbb{R}^n\to L\left(\mathbb{R}^n,\mathbb{R}\right)$ lässt sich dann eindeutig wie folgt darstellen \[\lambda \left( {{x_0}} \right) = \sum\limits_{i = 1}^n {{\lambda _i}\left( {{x_0}} \right)d{x^i}\left( {{x_0}} \right)} \] wobei $\lambda_i:\mathbb{R}^n\to\mathbb{R}$ Funktionen sind.
 \item Für jedes $f\in\subset'\left(\Omega\right)$\todo{Is it $C'$ or $\subset'$?? page 152.1 top} ist das differential $df$ eine $1-Form$ \[df = \frac{{\partial f}}{{\partial {x^1}}}d{x^1} + \frac{{\partial f}}{{\partial {x^2}}}d{x^2} +  \ldots  + \frac{{\partial f}}{{\partial {x^n}}}d{x^n}\]
 \item Der Ausdrück $\lambda\left(x,y,z\right)=3dx+5zdy+xdz$ definiert ein $1-$Form auf $\mathbb{R}^3$ mit 
 \begin{align*}
@@ -520,14 +520,14 @@ Eine beliebig $1-$Form $\lambda :\mathbb{R}^n\rightarrow L\left(\mathbb{R}^n,\ma
 \end{align*}
 \end{enumerate}
 \begin{definition}{8.28}
-Ein Vektorfeld auf $\Omega\subset\mathbb{R}^n$ ist eine Abbildung $v:\Omega\rightarrow\mathbb{R}^n$
+Ein Vektorfeld auf $\Omega\subset\mathbb{R}^n$ ist eine Abbildung $v:\Omega\to\mathbb{R}^n$
 \end{definition}\todo[inline]{Does the definition include the examples? page 153 top}
 
 \subsubsection*{Beispiel}
 \begin{enumerate}
 \item \begin{align*}
-v:\mathbb{R}^2 &\rightarrow\mathbb{R}^2\\
-\left( x,y\right) &\rightarrow\left( 2xy,x^2\right)
+v:\mathbb{R}^2 &\to\mathbb{R}^2\\
+\left( x,y\right) &\to\left( 2xy,x^2\right)
 \end{align*}
 
 \begin{center}
@@ -561,23 +561,23 @@ v:\mathbb{R}^2 &\rightarrow\mathbb{R}^2\\
 Sei $<,>$ das übliche Skalarprodukt auf $\mathbb{R}^n$, d.h. \[ < x,y > : = \sum\limits_{i = 1}^n {{x^i}{y^i}} \]
 Mittels $<,>$ kann man von $1-$Formen zu Vektorfelder und umgekehrt übergehen. Dies geht wie folgt:
 \begin{enumerate}
-\item Sei $v:\Omega\rightarrow\mathbb{R}^n$ ein Vektorfeld. Dann definieren wir $\forall x\in\Omega$, $\omega\in\mathbb{R}^n$
+\item Sei $v:\Omega\to\mathbb{R}^n$ ein Vektorfeld. Dann definieren wir $\forall x\in\Omega$, $\omega\in\mathbb{R}^n$
 \[\lambda (x)(\omega):= < v(x),\omega >\] Offensichtlich $\lambda (x)\in\left( \mathbb{R}^n, \mathbb{R}\right)$ und somit ist 
 \begin{align*}
-\lambda : \Omega &\rightarrow L\left(\mathbb{R}^n, \mathbb{R}\right) \\
-x &\rightarrow\lambda (x): \mathbb{R}^n \rightarrow\mathbb{R}\\
-&\hspace{17.5mm}\omega \rightarrow <v(x),\omega >
+\lambda : \Omega &\to L\left(\mathbb{R}^n, \mathbb{R}\right) \\
+x &\to\lambda (x): \mathbb{R}^n \to\mathbb{R}\\
+&\hspace{17.5mm}\omega \to <v(x),\omega >
 \end{align*}
 eine $1-$Form auf $\Omega$
 \end{enumerate}
 \underline{Umgekehrt}
 \begin{enumerate}[\indent 2.]
-\item Sei $\lambda :\Omega\rightarrow L\left(\mathbb{R}^n,\mathbb{R}\right)$ $1-$Form und $\lambda (x): = \sum\limits_{i = 1}^n {{\lambda _i}(x)d{x^i}} $ wie oben.\\
+\item Sei $\lambda :\Omega\to L\left(\mathbb{R}^n,\mathbb{R}\right)$ $1-$Form und $\lambda (x): = \sum\limits_{i = 1}^n {{\lambda _i}(x)d{x^i}} $ wie oben.\\
 
 Wir definieren 
 \begin{align*}
-v:\Omega &\rightarrow\mathbb{R}^n\\
-x &\rightarrow \left( \lambda _1(x),\lambda _2(x),\dots,\lambda _n(x) \right)
+v:\Omega &\to\mathbb{R}^n\\
+x &\to \left( \lambda _1(x),\lambda _2(x),\dots,\lambda _n(x) \right)
 \end{align*}
 dann ist $v$ ein Vektorfeld und \[\lambda (x)(\omega)= < v(x),\omega>\] Sei $\omega = \omega^1e_1+\omega^2 e_2 + \dots + \omega^n e_n$. Dann
 \begin{align*}
@@ -616,16 +616,16 @@ mit gleicheit für $e=\frac{\nabla f\left( x_0\right)}{\left| \nabla f\left( x_0
 $\nabla f\left( x_0\right)\not= 0\Rightarrow \nabla f\left( x_0\right)$ zeigt die Richtung an, in der $f$ am schnellsten wächst.\\
 
 \noindent \underline{Geometrische Interpretation}
-Sei $f:\mathbb{R}^n\rightarrow\mathbb{R}, C'$. Für jedes $s\in\mathbb{R}$ wird $f^{-1}(s)=\left\{ x\in\mathbb{R}^n\mid f(x)=s\right\}$ Niveaufläche genannt.
+Sei $f:\mathbb{R}^n\to\mathbb{R}, C'$. Für jedes $s\in\mathbb{R}$ wird $f^{-1}(s)=\left\{ x\in\mathbb{R}^n\mid f(x)=s\right\}$ Niveaufläche genannt.
 
 \subsubsection*{Beispiel}
 \begin{enumerate}
     \item \begin{align*}
- f:\mathbb{R}^3 &\rightarrow\mathbb{R}\\
- \left( x,y,z\right) &\rightarrow x^2 +y^2 +z^2
+ f:\mathbb{R}^3 &\to\mathbb{R}\\
+ \left( x,y,z\right) &\to x^2 +y^2 +z^2
  \end{align*}
 dann ist $f^{-1}(s)=$ Sphäre mit Zenter $O$ und Radius $\sqrt{s}$
-\item $f\left( x,y\right) = xy$ ist ein Hyperbolischer Parabolid mit Niveaulinien \missingfigure{page 158, bottom, use minipage} $f:\mathbb{R}^n \rightarrow\mathbb{R}$. Nun sei $x_0\in\Omega$ mit $f\left( x_0\right) = s$, i.e. $x_0 \in f^{-1} (s)$. Sei $\gamma :\lbrack -1,1\rbrack\rightarrow \mathbb{R}^n$ ein diff. kurve durch $x_0$ mit $\gamma\lbrack -1,1\rbrack\subset f^{-1}(s)$, $\gamma (0)=x_0$
+\item $f\left( x,y\right) = xy$ ist ein Hyperbolischer Parabolid mit Niveaulinien \missingfigure{page 158, bottom, use minipage} $f:\mathbb{R}^n \to\mathbb{R}$. Nun sei $x_0\in\Omega$ mit $f\left( x_0\right) = s$, i.e. $x_0 \in f^{-1} (s)$. Sei $\gamma :\lbrack -1,1\rbrack\to \mathbb{R}^n$ ein diff. kurve durch $x_0$ mit $\gamma\lbrack -1,1\rbrack\subset f^{-1}(s)$, $\gamma (0)=x_0$
 \missingfigure{page 159, middle} 
 Dann gilt $f\left( \gamma (t)\right)=s$, $\forall t\in\lbrack -1,1\rbrack$ und es folgt aus Kettenregel
 \[\begin{array}{l}%Find if there is a better way to do this
@@ -670,8 +670,8 @@ In diesem Kapitel werden wir das ``Wegintegral'' von $1-$Formen oder \todo{can't
 \subsection*{Parameterdarstellung einer Kurve}
 Sei $\gamma\subset\mathbb{R}^n$ eine Kurve. Eine Parameterdarstellung (PD) von $\gamma$ ist eine Funktion 
 \begin{align*}
-\gamma : I=\lbrack a,b\rbrack &\rightarrow\mathbb{R}^n\\
-t &\rightarrow \gamma (t)
+\gamma : I=\lbrack a,b\rbrack &\to\mathbb{R}^n\\
+t &\to \gamma (t)
 \end{align*}
 wobei $\gamma\left( t\right)$ ein Punkt $\gamma$ ist und jeder Punkt auf $\gamma$ kann als $\gamma\left( t\right)$ dargestellt werden
 \[\gamma\left( t\right) = \left( \gamma_1 (t),\dots,\gamma_n (t)\right)\]
@@ -736,7 +736,7 @@ Das Wegintegral von $\vartheta$ langs $\gamma$
 \[\int\limits_\gamma  {vd\vec s}  = \int\limits_\gamma  {v(\gamma )d\gamma : = \int\limits_a^b { < v\left( {\gamma \left( t \right)} \right),\gamma '(t) > dt} } \] ${vd\vec s}=\gamma'(t)dt$ heisst gerichtetes Längeelement
 \end{definition}
 \subsubsection*{Beispiel 8.34}
-Ein einführendes Beispiel: Sei ein Massenpunkt, der sich unter den Einfluss eines Kraftfeldes $F:\mathbb{R}^2\rightarrow\mathbb{R}$ bewegt.\\
+Ein einführendes Beispiel: Sei ein Massenpunkt, der sich unter den Einfluss eines Kraftfeldes $F:\mathbb{R}^2\to\mathbb{R}$ bewegt.\\
 
 Wenn der Massenpunkt durch eine Konstante Kraft $\overrightarrow F $ längs einer Geraden um den Vektor $\vec s$ verschoben. \\
 
@@ -763,10 +763,10 @@ W = &\int\limits_a^b {F\left( {\gamma \left( t \right)} \right)}  \cdot \gamma '
 \subsubsection*{Bemerkung 8.35}
 Wir können das Wegintegral auch mit Differentialformen formulieren. Sei 
 \begin{align*}
-v:\Omega &\rightarrow\mathbb{R}^n\\
-x &\rightarrow\left( v^i(x)\right)_{i=1}^n
+v:\Omega &\to\mathbb{R}^n\\
+x &\to\left( v^i(x)\right)_{i=1}^n
 \end{align*}
-ein stetiges Vektorfeld ($v^i(x):\mathbb{R}^n\rightarrow\mathbb{R}$ stetig) dann ist durch $\lambda (x)(\omega):=< v(x),\omega >$ definierte $\lambda (x)\in L\left( \mathbb{R}^n,\mathbb{R}\right)$ eine $1-$Form
+ein stetiges Vektorfeld ($v^i(x):\mathbb{R}^n\to\mathbb{R}$ stetig) dann ist durch $\lambda (x)(\omega):=< v(x),\omega >$ definierte $\lambda (x)\in L\left( \mathbb{R}^n,\mathbb{R}\right)$ eine $1-$Form
 \begin{align*}
 \int\limits_\gamma  {vd\vec s}  = &\int\limits_a^b { < v\left( {\gamma (t)} \right),\gamma '(t) > dt}\\
  = &\int\limits_a^b {\lambda \left( {\gamma \left( t \right)} \right)\left( {\gamma '\left( t \right)} \right)dt} 
@@ -774,17 +774,17 @@ ein stetiges Vektorfeld ($v^i(x):\mathbb{R}^n\rightarrow\mathbb{R}$ stetig) dann
 
 \noindent\underline{Umgekehrt}\\
 
-\noindent Sei $\lambda :\Omega\rightarrow L\left( \mathbb{R}^n,\mathbb{R}\right)$ eine $1-$Form die in Folgende Sinne stetig ist: \\
+\noindent Sei $\lambda :\Omega\to L\left( \mathbb{R}^n,\mathbb{R}\right)$ eine $1-$Form die in Folgende Sinne stetig ist: \\
 
 Sei 
 \begin{align*}
-\gamma :\lbrack a,b\rbrack &\rightarrow\Omega\\
-t &\rightarrow\left( \gamma^1 (t), \gamma^2 (t),\dots ,\gamma^n (t) \right)
+\gamma :\lbrack a,b\rbrack &\to\Omega\\
+t &\to\left( \gamma^1 (t), \gamma^2 (t),\dots ,\gamma^n (t) \right)
 \end{align*}
 ein $C'-$weg. Dann ist 
 \begin{align*}
-\lbrack a,b\rbrack \rightarrow &\mathbb{R}\\
-t\rightarrow &\lambda\left( \gamma (t)\right)\left( \gamma' (t)\right)\\
+\lbrack a,b\rbrack \to &\mathbb{R}\\
+t\to &\lambda\left( \gamma (t)\right)\left( \gamma' (t)\right)\\
 & = \sum{\lambda_i\left(\gamma(t)\right)\cdot\frac{d\gamma^i}{dt}(t)}
 \end{align*}
 eine Stetige Funktion somit ist das Integral $\int\limits_a^b {\lambda \left( {\gamma \left( t \right)} \right)\left( {\gamma '\left( t \right)} \right)dt} $ wohl definiert. 
@@ -796,11 +796,24 @@ Das Wegintegral von $\gamma\in L\left( \mathbb{R}^n,\mathbb{R}\right)$ längs $\
 \subsubsection*{Beispiel 8.37}
 \begin{enumerate}
 \item Sei $\gamma\in C'\left(\lbrack 0,2\pi\rbrack =\mathbb{R}^2\right)$ mit 
-\[\begin{array}{*{20}{c}}{\gamma (t) = \left( {\begin{array}{*{20}{c}}{\cos t}\\{\sin t}\end{array}} \right)}&{}\\{}&{0 \le t \le 2\pi }\\{\gamma '(t) = \left( {\begin{array}{*{20}{c}}{ - \sin t}\\{\cos t}\end{array}} \right)}&{}\end{array}\]
+\[\begin{array}{*{20}{c}}
+{\gamma (t) = \left( {\begin{array}{*{20}{c}}
+{\cos t}\\
+{\sin t}
+\end{array}} \right)}&{}\\
+{}&{0 \le t \le 2\pi }\\
+{\gamma '(t) = \left( {\begin{array}{*{20}{c}}
+{ - \sin t}\\
+{\cos t}
+\end{array}} \right)}&{}
+\end{array}\]
 eine Parametrisierung des Einheitskreises $\lambda = \lambda (x,y)$ die $1-$Form mit \[\lambda (x,y)=-ydx+xdy\hspace{10mm}(x,y)\in\mathbb{R}^2\]
 Dann gilt 
 \begin{align*}
-\int\limits_\gamma  \lambda   = &\int\limits_0^{2\pi } {\underbrace {\left( { - \sin t,\cos t} \right)}_{\lambda (\gamma (t))} \cdot \underbrace {\left( {\begin{array}{*{20}{c}}{ - \sin t}\\{\cos t}\end{array}} \right)}_{\gamma '(t)}dt} \\
+\int\limits_\gamma  \lambda   = &\int\limits_0^{2\pi } {\underbrace {\left( { - \sin t,\cos t} \right)}_{\lambda (\gamma (t))} \cdot \underbrace {\left( {\begin{array}{*{20}{c}}
+{ - \sin t}\\
+{\cos t}
+\end{array}} \right)}_{\gamma '(t)}dt} \\
 = &\int\limits_0^{2\pi } {\left( {{{\sin }^2}t + {{\cos }^2}t} \right)dt}  = 2\pi 
 \end{align*}
 \item Sei $\gamma (x,y)=3x^2ydx + \left( x^3+1\right)dy$. Wir betrachten die Kurvenintegral längs verschiederer Wege
@@ -811,11 +824,11 @@ Dann gilt
 \end{align*}
 \subsubsection*{Bemerkung}\todo{is  this inside the enumerated list or out?? page 170 bottom}
 Sei $f(x,y)=x^3y+y$. Dann ist  \[df(x+y)=3x^2ydx+\left( x^3+1\right) dy\] und \[f(1,1)-f(0,0)=(1+1)-(0,0)=2\]
-Wir können der Begriff des Wegintegrals auf Wege zu erweitern die Stückweise $C'$ sind. Ein Stückweise $C'-$Weg ist eine Stetige Abbildung $\gamma :\lbrack a,b\rbrack\rightarrow\mathbb{R}^n$ mit einer Unterteilung des Intervals 
+Wir können der Begriff des Wegintegrals auf Wege zu erweitern die Stückweise $C'$ sind. Ein Stückweise $C'-$Weg ist eine Stetige Abbildung $\gamma :\lbrack a,b\rbrack\to\mathbb{R}^n$ mit einer Unterteilung des Intervals 
 \[a=a_0 < a_1 < a_2 < \dots <a_n = b\] 
 so dass \[{\left. \gamma  \right|_{\left[ {{a_i},{a_{i + 1}}} \right]}} = \left[ {{a_i},{a_{i + 1}}} \right] \to \mathbb{R}^n \] $C'$ ist.\\
 
-\noindent d.h. $t\rightarrow\gamma'(t)$ ist auf $\left( a_i, a_{i+1}\right)$ stetig und erweitert sich stetig auf $\lbrack a_i, a_{i+1}\rbrack$
+\noindent d.h. $t\to\gamma'(t)$ ist auf $\left( a_i, a_{i+1}\right)$ stetig und erweitert sich stetig auf $\lbrack a_i, a_{i+1}\rbrack$
 \subsubsection*{Beispiel}\todo{is  this inside the enumerated list or out?? page 171 middle}
 \missingfigure{Page 171 bottom}
 Dann definiert man
@@ -827,22 +840,25 @@ Jetzt werden wir einzige Grundlegenden Eigenschaften des Wegintegrals herleiten.
 Eigenschaften des Wegintegrals
 \begin{enumerate}[\indent E1)]
 \item Das Wegintegral $\int\limits_\gamma  \lambda  $ ist unabhängig von einer orientierungsverhaltenden umparametrisierung. \\
-D.h. Sei $\gamma :\lbrack a,b\rbrack\rightarrow\Omega$, $C'$ und $\varphi :\lbrack a',b'\rbrack\rightarrow\lbrack a,b\rbrack$, $C'$ mit $\varphi\left( a'\right)=a$, $\varphi\left( b'\right)=b$, $\varphi'\left( t\right) >0$ $\forall t\in\lbrack a', b'\rbrack$. Dann ist 
+D.h. Sei $\gamma :\lbrack a,b\rbrack\to\Omega$, $C'$ und $\varphi :\lbrack a',b'\rbrack\to\lbrack a,b\rbrack$, $C'$ mit $\varphi\left( a'\right)=a$, $\varphi\left( b'\right)=b$, $\varphi'\left( t\right) >0$ $\forall t\in\lbrack a', b'\rbrack$. Dann ist 
 \begin{align*}
 \int\limits_{\gamma  \circ \varphi } \lambda   = &\int\limits_{a'}^{b'} {\lambda \left( {\gamma \left( {\varphi (t)} \right)} \right)\left( {\gamma  \circ \varphi } \right)'(t)dt} \\
  = &\int\limits_{a'}^{b'} {\lambda \left( {\gamma \left( {\varphi (t)} \right)} \right)\gamma '\left( {\varphi (t)} \right)\varphi '(t)dt} \\
  = &\int\limits_a^b {\lambda \left( {\gamma \left( s \right)} \right)\gamma '\left( s \right)ds = \int\limits_\gamma  \lambda  } 
 \end{align*}
 Geometrisch heisst dies, dass $\int\limits_\gamma  \lambda$ nur vom Bild $\gamma\left( \lbrack a,b\rbrack\right)$ mit vorgegebenen Durchlaufsinn abhängt
-\item Seien $\gamma_1:\lbrack a_1,b_1\rbrack\rightarrow\Omega$ und $\gamma_2:\lbrack a_2,b_2\rbrack\rightarrow\Omega$ zwei Wege mit $\gamma_1\left( b_1\right)=\gamma_2\left(a_2\right)$ 
+\item Seien $\gamma_1:\lbrack a_1,b_1\rbrack\to\Omega$ und $\gamma_2:\lbrack a_2,b_2\rbrack\to\Omega$ zwei Wege mit $\gamma_1\left( b_1\right)=\gamma_2\left(a_2\right)$ 
 \missingfigure{Page 173, middle to top}
 Wir definieren $\gamma_1+\gamma_2$ der Weg der durch aneinanderhängen von $\gamma_1$ mit $\gamma_2$ entsteht, d.h.
-\[{\gamma _1} + {\gamma _2} = \left\{ {\begin{array}{*{20}{c}}{{\gamma _1}(t)}&{t \in \left[ {{a_1},{b_1}} \right]}\\{{\gamma _2}\left( {t - {b_1} + {a_2}} \right)}&{t \in \left[ {{b_1},{b_1} + {b_2} - {a_2}} \right]}\end{array}} \right.\]
+\[{\gamma _1} + {\gamma _2} = \left\{ {\begin{array}{*{20}{c}}
+{{\gamma _1}(t)}&{t \in \left[ {{a_1},{b_1}} \right]}\\
+{{\gamma _2}\left( {t - {b_1} + {a_2}} \right)}&{t \in \left[ {{b_1},{b_1} + {b_2} - {a_2}} \right]}
+\end{array}} \right.\]
 Dann gilt \[\int\limits_{{\gamma _1} + {\gamma _2}} \lambda   = \int\limits_{{\gamma _1}} \lambda   + \int\limits_{{\gamma _2}} \lambda  \]
-\item Sei $\gamma:\lbrack a,b\rbrack\rightarrow\Omega$ ein Weg. Dann sei $-\gamma:\lbrack a,b\rbrack\rightarrow\Omega$ der Gleiche Weg aber im entgegengesetzen Durchlaufsinn, d.h. $\left( -\gamma\right) (t)=\gamma\left( -t+a+b\right)$ 
+\item Sei $\gamma:\lbrack a,b\rbrack\to\Omega$ ein Weg. Dann sei $-\gamma:\lbrack a,b\rbrack\to\Omega$ der Gleiche Weg aber im entgegengesetzen Durchlaufsinn, d.h. $\left( -\gamma\right) (t)=\gamma\left( -t+a+b\right)$ 
 \missingfigure{page 174, middle to top}
 Dann gilt \[\int\limits_{ - \gamma } \lambda   =  - \int\limits_\gamma  \lambda  \]
-\item Sei $f:\Omega\rightarrow\mathbb{R}$ eine $C'-$Funktion, sowie $\gamma:\lbrack a,b\rbrack\rightarrow\Omega$ Stückweise $C'$. Dann gilt \[\int\limits_\gamma  {df}  = f\left( {\gamma \left( b \right)} \right) - f\left( {\gamma \left( a \right)} \right)\]
+\item Sei $f:\Omega\to\mathbb{R}$ eine $C'-$Funktion, sowie $\gamma:\lbrack a,b\rbrack\to\Omega$ Stückweise $C'$. Dann gilt \[\int\limits_\gamma  {df}  = f\left( {\gamma \left( b \right)} \right) - f\left( {\gamma \left( a \right)} \right)\]
 $\gamma$ ist $C'$, dann ist 
 \begin{align*}
 \int\limits_\gamma  {df}  = & \int\limits_a^b {df\left( {\gamma \left( t \right)} \right)\gamma '\left( t \right)dt} \\
@@ -856,22 +872,22 @@ Mittels den Wegintegrals können wir die $C'-$Funktionen charakterisieren deren 
 \subsubsection*{Satz 8.39}
 Sei $\Omega$ ``Offen'' und \todo{Can't read, page 175 middle} $\left( C'-\right)$Wegzusammenhängend. Sei $f\in C'\left(\Omega\right)$ falls $df(x)=0$, $\forall x\in\Omega$ so ist $f$ konstant.
 \subsubsection*{Beweis}
-$\Omega$ wegzusammenhängend heisst dass zu je zwei Punkten $x,y\in\Omega$ gibt es in $C'-$Weg $\gamma :\lbrack 0,1\rbrack\rightarrow\gamma$ mit $\gamma(0)=x$ und $\gamma(1)=y$, $\gamma\left(\lbrack 0,1\rbrack\right)\subset\Omega$. Dann folgt
+$\Omega$ wegzusammenhängend heisst dass zu je zwei Punkten $x,y\in\Omega$ gibt es in $C'-$Weg $\gamma :\lbrack 0,1\rbrack\to\gamma$ mit $\gamma(0)=x$ und $\gamma(1)=y$, $\gamma\left(\lbrack 0,1\rbrack\right)\subset\Omega$. Dann folgt
 \begin{align*}
 f(y)-f(x)=& f\left(\gamma(1)\right)-f\left(\gamma(0)\right)\\
 = &\int\limits_{\gamma} df = 0
 \end{align*}
 $\Rightarrow f(y)=f(x)$, $\forall x,y\in\Omega\Rightarrow f$ ist konstant.\\
 
-\noindent\underline{Frage:} Wann ist eine $1-$Form $\lambda$, von der form $\lambda = df$, d.h. differential einer Funktion? d.h. gegeben eine $1-$Form $\lambda$, gibt es eine Funktion $f:\Omega\rightarrow\mathbb{R}$ s.d. $df=\lambda$\\
+\noindent\underline{Frage:} Wann ist eine $1-$Form $\lambda$, von der form $\lambda = df$, d.h. differential einer Funktion? d.h. gegeben eine $1-$Form $\lambda$, gibt es eine Funktion $f:\Omega\to\mathbb{R}$ s.d. $df=\lambda$\\
 
-Wenn ein $f:\Omega\rightarrow\mathbb{R}$ gibt so dass $df=\lambda$, heisst $f$ ein Potential. (Potential ist wie ein Stammfunktion für ein $1-$Form). Mittels Wegintegral,stellen wir jetzt ein Kriterium
+Wenn ein $f:\Omega\to\mathbb{R}$ gibt so dass $df=\lambda$, heisst $f$ ein Potential. (Potential ist wie ein Stammfunktion für ein $1-$Form). Mittels Wegintegral,stellen wir jetzt ein Kriterium
 
 \subsubsection*{Satz 8.30}
-Sei $\lambda\in\Omega\rightarrow L\left( \mathbb{R}^n,\mathbb{R}\right)$ eine Stetige $1-$Form. Folgende Aussage sind äquivalent
+Sei $\lambda\in\Omega\to L\left( \mathbb{R}^n,\mathbb{R}\right)$ eine Stetige $1-$Form. Folgende Aussage sind äquivalent
 \begin{enumerate}
 \item Es gibt $f\in C'\left( \Omega\right)$ mit $df=\Omega$
-\item Für je zwei Stückweise $C'-$Wege $\gamma_i=\lbrack a_i,b_i\rbrack\rightarrow\Omega$ mit selben Anfangs und Endpunkten (d.h. $\gamma_1\left( a_1\right)=\gamma_2\left(a_2\right)$, $\gamma_1\left( b_1\right)=\gamma_2\left(b_2\right)$) gilt \[\int\limits_{{\gamma _1}} \lambda   = \int\limits_{{\gamma _2}} \lambda  \]
+\item Für je zwei Stückweise $C'-$Wege $\gamma_i=\lbrack a_i,b_i\rbrack\to\Omega$ mit selben Anfangs und Endpunkten (d.h. $\gamma_1\left( a_1\right)=\gamma_2\left(a_2\right)$, $\gamma_1\left( b_1\right)=\gamma_2\left(b_2\right)$) gilt \[\int\limits_{{\gamma _1}} \lambda   = \int\limits_{{\gamma _2}} \lambda  \]
 \item Für jede geschlossene $C'$Weg $\gamma$ gilt \[\int\limits_\gamma  \lambda   = 0\]
 \end{enumerate} 
 
@@ -879,20 +895,20 @@ Sei $\lambda\in\Omega\rightarrow L\left( \mathbb{R}^n,\mathbb{R}\right)$ eine St
 \begin{enumerate}[align=left]
 \item[$(1)\Rightarrow (2)$:] Folgt aus E4) 
 \item[$(2)\Leftrightarrow (3)$:] Klar
-\item[$(2)\Rightarrow (1)$:] Sei $p_0\in\Omega$; für jedes $x\in\Omega$. Sei $\gamma:\lbrack 0,1\rbrack\rightarrow\Omega$ Stückweise $C'$ mit $\gamma(0)=p_0$, $\gamma(1)=x$. Definiere $f(x): = \int\limits_\gamma  \lambda $.\\
+\item[$(2)\Rightarrow (1)$:] Sei $p_0\in\Omega$; für jedes $x\in\Omega$. Sei $\gamma:\lbrack 0,1\rbrack\to\Omega$ Stückweise $C'$ mit $\gamma(0)=p_0$, $\gamma(1)=x$. Definiere $f(x): = \int\limits_\gamma  \lambda $.\\
 
 Dann ist $f$ nach Annahme (2) Wohldefiniert (d.h. unabhängig von dem Weg von $p_0$ nach $x$) (Wir können $f$ auch mit $\int\limits_{{p_0}}^x \lambda  $ bezeichnen)
 \end{enumerate}
 
 \subsubsection*{Behauptung}
 $f\in C'\left( \Omega\right)$ und $df=\lambda$. Um zu zeigen dass $df=\lambda$ müssen wir zeigen dass für $x,x_0\in\Omega$
-\[f\left(x\right)-f\left(x_0\right)=\lambda\left(x_0\right)\left( x-x_0\right)+R\left( x,x_0\right)\] mit $\frac{R\left( x,x_0\right)}{\left| x-x_0\right|}\rightarrow 0$.\\
+\[f\left(x\right)-f\left(x_0\right)=\lambda\left(x_0\right)\left( x-x_0\right)+R\left( x,x_0\right)\] mit $\frac{R\left( x,x_0\right)}{\left| x-x_0\right|}\to 0$.\\
 
-\noindent Sei $x_0\in\mathbb{R}$. Sei $\gamma_1:\lbrack -1,0\rbrack\rightarrow\Omega$ ein Weg von $p_0$ nach $x_0$. Dann gilt \[\int\limits_{{\gamma _1}} \lambda   = f\left( {{x_0}} \right)\]
+\noindent Sei $x_0\in\mathbb{R}$. Sei $\gamma_1:\lbrack -1,0\rbrack\to\Omega$ ein Weg von $p_0$ nach $x_0$. Dann gilt \[\int\limits_{{\gamma _1}} \lambda   = f\left( {{x_0}} \right)\]
 Sei
 \begin{align*}
-\gamma_x:\lbrack 0,1\rbrack &\rightarrow\Omega\\
-t &\rightarrow (1-t)x_0+tx
+\gamma_x:\lbrack 0,1\rbrack &\to\Omega\\
+t &\to (1-t)x_0+tx
 \end{align*}
 \missingfigure{Page 178 bottom}
 Um $\gamma^x\left( \lbrack 0,1\rbrack\right)\subset\Omega$ zu garantieren, nehmen wir $r>0$ so dass $B_r\left( x_0\right)\subset\Omega$ und nehmen an, dass $x\in B_r\left( x_0\right)$. Dann ist
@@ -937,11 +953,11 @@ und $df\left( x,y\right)=2xy^2dx+2x^2ydy$.\\
 Analog wie für $1-$Formen kann man Satz 8.30 für Vektorfelder Formulieren
 
 \begin{definition}{8.32}
-Ein Vektorfeld $v:\Omega\rightarrow\mathbb{R}^n$ heisst konservative falls $\forall\gamma:\lbrack 0,1\rbrack\rightarrow\Omega$ geschlossen \[\int\limits_\gamma v ds=0\]
+Ein Vektorfeld $v:\Omega\to\mathbb{R}^n$ heisst konservative falls $\forall\gamma:\lbrack 0,1\rbrack\to\Omega$ geschlossen \[\int\limits_\gamma v ds=0\]
 \end{definition}
 Aus Satz 8.30 Folgt
 \subsubsection*{Satz 8.33}
-Für eine Stetige Vektorfeld $v:\Omega\rightarrow\mathbb{R}^n$ sind folgende Aussagen equivalent
+Für eine Stetige Vektorfeld $v:\Omega\to\mathbb{R}^n$ sind folgende Aussagen equivalent
 \begin{enumerate}
 \item $v$ ist Konservative
 \item Es gibt $f\in C'\left( \Omega\right)$ mit $v=\nabla f$. In diesem Fall heisst $v$ Potentialfeld mit dem Potential $f$.
@@ -953,7 +969,7 @@ Im Nächsten Kapitel, mittels höhere Partielle Ableitungen, erhalten wir eine e
 
 \section{Höhere Ableitungen}
 \begin{definition}{8.44}
-$f:\Omega\rightarrow\mathbb{R}$, $\Omega\subset\mathbb{R}^n$ $f\in C'\left( \Omega\right)$ heisst von Klasse $C^2$ falls $\frac{\partial f}{\partial x^i}\in C'{\left( \Omega\right)}_{1\leq i\leq n}$
+$f:\Omega\to\mathbb{R}$, $\Omega\subset\mathbb{R}^n$ $f\in C'\left( \Omega\right)$ heisst von Klasse $C^2$ falls $\frac{\partial f}{\partial x^i}\in C'{\left( \Omega\right)}_{1\leq i\leq n}$
 \end{definition}\todo{Where does the definition end? page 183 top}
 Für beliebiges $m$, die Funktion $f\in C'\left( \omega\right)$ heisst von der Klasse $C^m$, $f\in C^m\left( \omega\right)$ falls $\frac{\partial f}{\partial x^i}\in C^{m-1}\left( \Omega\right)$, $1\leq i\leq n$\\
 
@@ -972,7 +988,7 @@ Im Allgemein
 Für jede $C^k-$Funktion sind alle Partielle Ableitungen vom Grad $\leq k$ von der Reihenfolge der Ableitungen unabhängig. Von Satz 8.35 erhalten wir folgende notwendige Bedingung für konservativität
 
 \subsubsection*{Korollar 8.47}
-Sei $v:\Omega\rightarrow\mathbb{R}^n$, $v={\left( v^i\right)}_{1\leq i \leq n}$ ein $C'-$Vektorfeld. Falls $v$ konservativ ist, folgt 
+Sei $v:\Omega\to\mathbb{R}^n$, $v={\left( v^i\right)}_{1\leq i \leq n}$ ein $C'-$Vektorfeld. Falls $v$ konservativ ist, folgt 
 \[\frac{{\partial {v^i}}}{{\partial {x^j}}} = \frac{{\partial {v^j}}}{{\partial {x^i}}}\hspace{5mm}1 \le i,j \le n\]
 
 \subsubsection*{Beweis}
@@ -982,19 +998,25 @@ folgt.
 
 \subsubsection*{Beispiel 8.48}
 \begin{enumerate}
-\item \[v\left( {x,y} \right) = \left( {\begin{array}{*{20}{c}}{4x{y^2}}\\{2y}\end{array}} \right)\]
+\item \[v\left( {x,y} \right) = \left( {\begin{array}{*{20}{c}}
+{4x{y^2}}\\
+{2y}
+\end{array}} \right)\]
 Es gilt $\frac{\partial v'}{\partial y}=8xy$, $\frac{\partial v^2}{dx}=2$. Also ist $v$ nicht konservativ
-\item Sei $\Omega = \left\{ \left( x,y\right) \in\mathbb{R}^2:\left( x,y\right) \not= (0,0) \right\} = \mathbb{R}^2\backslash\left\{ 0,0\right\}$ und \[v(x,y) = \left( {\frac{{ - y}}{{{x^2} + {y^2}}},\frac{x}{{{x^2} + {y^2}}}} \right)\] Dann $v:\Omega \rightarrow\mathbb{R}^2$ mindestens $C'$. Ausserdem \[\frac{{\partial v'}}{{\partial y}} = \frac{{{y^2} - {x^2}}}{{{{\left( {{x^2} + {y^2}} \right)}^2}}} = \frac{{\partial {v^2}}}{{\partial x}}\] Jetzt berechnen wir $\int\limits_C v ds$, wobei C: 
+\item Sei $\Omega = \left\{ \left( x,y\right) \in\mathbb{R}^2:\left( x,y\right) \not= (0,0) \right\} = \mathbb{R}^2\backslash\left\{ 0,0\right\}$ und \[v(x,y) = \left( {\frac{{ - y}}{{{x^2} + {y^2}}},\frac{x}{{{x^2} + {y^2}}}} \right)\] Dann $v:\Omega \to\mathbb{R}^2$ mindestens $C'$. Ausserdem \[\frac{{\partial v'}}{{\partial y}} = \frac{{{y^2} - {x^2}}}{{{{\left( {{x^2} + {y^2}} \right)}^2}}} = \frac{{\partial {v^2}}}{{\partial x}}\] Jetzt berechnen wir $\int\limits_C v ds$, wobei C: 
 \missingfigure{page 186, middle. Also add the formula describing $C(t)$ using a minipage}
 \begin{align*}
 \int\limits_C vds  = & \int\limits_0^{2\pi } { < v\left( {C\left( t \right)} \right),C'\left( t \right) > dt} \\
-= & \int\limits_0^{2\pi } \left( -\sin t,\cos t\right)\cdot  \left( {\begin{array}{*{20}{c}}{ - \sin t}\\{\cos t}\end{array}} \right) dt\\
+= & \int\limits_0^{2\pi } \left( -\sin t,\cos t\right)\cdot  \left( {\begin{array}{*{20}{c}}
+{ - \sin t}\\
+{\cos t}
+\end{array}} \right) dt\\
 = & \int\limits_0^{2\pi } \left( \sin^2 t+\cos^2 t\right) dt=2\pi\not= 0\\
 \Rightarrow &\text{ $v$ auf $\Omega$ ist nicht konservativ!}
 \end{align*}
 Jetzt betrachten wir $\Omega'=\left\{ \left( x,y\right) \mid x>0 \right\}$ \todo{can't understand image on page 187, top} und führen Polarkoordinaten ein \[x=r\cos\theta, y=r\sin\theta\hspace{10mm} -\frac{\pi}{2}<\theta <\frac{\pi}{2}\]
 Dann ist $\tan\theta = \frac{y}{x}$ und \[\theta=\arctan\frac{y}{x}\]
-Wir betrachten $\theta:\Omega'\rightarrow\mathbb{R}$ als ein Funktion der Variabeln $x,y$ und berechnen 
+Wir betrachten $\theta:\Omega'\to\mathbb{R}$ als ein Funktion der Variabeln $x,y$ und berechnen 
 \begin{align*}
 \frac{{\partial \theta }}{{\partial x}} = & \frac{1}{{1 + {{\left( {\frac{y}{x}} \right)}^2}}}\left( { - \frac{y}{{{x^2}}}} \right) =  - \frac{y}{{{x^2} + {y^2}}}\\
 \frac{{\partial \theta }}{{\partial x}} = & \frac{x}{{{x^2} + {y^2}}}
@@ -1025,14 +1047,14 @@ Sei $\Omega\in\mathbb{R}^2$ beschränkt zusammenhängend sowie einfachzusammenh�
 \subsection*{Taylorentwicklung und der lokale Verhalten von $C^m-$Funktionen}\todo[inline]{Not sure how big of a title...}
 Wir werden jetzt ein Verallgemeinerung der $1.$ Variablen Taylorentwicklung herleiten. \\
 
-Sei $f:\mathbb{R}^n\rightarrow\mathbb{R}$ eine $C^m-$Funktion sowie $x_0,x_1\in\mathbb{R}^n$. (Allgemein könnte man $\mathbb{R}^n$ durch eine offene konvexe Menge ersetzen)\\
+Sei $f:\mathbb{R}^n\to\mathbb{R}$ eine $C^m-$Funktion sowie $x_0,x_1\in\mathbb{R}^n$. (Allgemein könnte man $\mathbb{R}^n$ durch eine offene konvexe Menge ersetzen)\\
 
 \noindent Sei
 \begin{align*} 
-\varphi:\mathbb{R} &\rightarrow\mathbb{R}^n\\
-t & \rightarrow \left( 1-t\right) x_0+x_1
+\varphi:\mathbb{R} &\to\mathbb{R}^n\\
+t & \to \left( 1-t\right) x_0+x_1
 \end{align*}
-Dann ist $g:=f\circ\varphi:\mathbb{R}\rightarrow\mathbb{R}$ eine \todo[inline]{Dont know where this actually fits: $\left( g(0)=f=\left( x_0\right), g(1)=f\left( x_1\right)\right)$}$C^m-$Funktion und (nach Taylor \todo{can't read, page 189 bottom} von Funktionen $1-$variable) es gibt $\xi\in (0,1)$ so dass 
+Dann ist $g:=f\circ\varphi:\mathbb{R}\to\mathbb{R}$ eine \todo[inline]{Dont know where this actually fits: $\left( g(0)=f=\left( x_0\right), g(1)=f\left( x_1\right)\right)$}$C^m-$Funktion und (nach Taylor \todo{can't read, page 189 bottom} von Funktionen $1-$variable) es gibt $\xi\in (0,1)$ so dass 
 
 \[
 g\left( {} \right) = g\left( 0 \right) + g'\left( 0 \right) +  \ldots  + \frac{{{g^{\left( {m - 1} \right)}}\left( 0 \right)}}{{\left( {m - 1} \right)!}} + \frac{{{g^{\left( m \right)}}\left( \xi  \right)}}{{m!}}\tag{\textasteriskcentered\label{Chap8Equation,Taylor}}
@@ -1058,7 +1080,11 @@ Daraus schliesst man induktive das
 Eingesetzt in (\textasteriskcentered) (s.\pageref{Chap8Equation,Taylor}) ergibt \todo[inline]{MISSING CONTENT?? page 191 bottom}
 
 \subsubsection*{Satz 8.51(Taylor entwicklung)}
-\begin{align*}f\left( {{x_1}} \right) = & f\left( {{x_0}} \right) + \sum\limits_{i = 1}^n {\frac{{\partial f}}{{\partial x'}}\left( {{x_0}} \right)\left( {x_1^i - x_0^i} \right) +  \ldots } \\ + & \frac{1}{{\left( {m - 1} \right)!}}\sum\limits_{{i_1}, \ldots ,{i_{m - 1}} = 1}^n {\frac{{{\partial ^{m - 1}}f}}{{\partial {x^{{i_1}}} \ldots \partial {x^{{i_{m - 1}}}}}}\left( {{x_0}} \right)\prod\limits_{l = 1}^{\left( {m - 1} \right)} {\left( {x_1^{{i_l}} - x_0^{{i_l}}} \right)} } \\ + & \frac{1}{{m!}}\sum\limits_{{i_1}, \ldots ,{i_m} = 1}^n {\frac{{{\partial ^m}f}}{{\partial {x^{{i_1}}} \ldots \partial {x^{{i_m}}}}}\left( {{x_\xi }} \right)\prod\limits_{l = 1}^m {\left( {x_1^{{i_l}} - x_0^{{i_l}}} \right)} } \end{align*}
+\begin{align*}
+f\left( {{x_1}} \right) = & f\left( {{x_0}} \right) + \sum\limits_{i = 1}^n {\frac{{\partial f}}{{\partial x'}}\left( {{x_0}} \right)\left( {x_1^i - x_0^i} \right) +  \ldots } \\
+ + & \frac{1}{{\left( {m - 1} \right)!}}\sum\limits_{{i_1}, \ldots ,{i_{m - 1}} = 1}^n {\frac{{{\partial ^{m - 1}}f}}{{\partial {x^{{i_1}}} \ldots \partial {x^{{i_{m - 1}}}}}}\left( {{x_0}} \right)\prod\limits_{l = 1}^{\left( {m - 1} \right)} {\left( {x_1^{{i_l}} - x_0^{{i_l}}} \right)} } \\
+ + & \frac{1}{{m!}}\sum\limits_{{i_1}, \ldots ,{i_m} = 1}^n {\frac{{{\partial ^m}f}}{{\partial {x^{{i_1}}} \ldots \partial {x^{{i_m}}}}}\left( {{x_\xi }} \right)\prod\limits_{l = 1}^m {\left( {x_1^{{i_l}} - x_0^{{i_l}}} \right)} } 
+\end{align*}
 mit eine Zahl $\xi\in\left( 0,1\right)$, $x_\xi = \left( 1-\xi\right)x_0+\xi x_1$.
 
 \subsubsection*{Bemerkung 8.52}
@@ -1068,13 +1094,18 @@ f\left( {{x_1}} \right) = & f\left( {{x_0}} \right) + \nabla f\left( {{x_0}} \ri
  + &\frac{1}{2}\sum\limits_{i,j = 1}^2 {\frac{{{\partial ^2}f}}{{\partial {x^i}\partial {x^j}}}\left( {{x_0}} \right)\left( {x_1^i - x_0^i} \right)} \left( {x_1^j - x_0^j} \right) + {r_2}\left( {f,{x_1},{x_0}} \right)
 \end{align*}
 mit Fehler 
-\[\frac{r_2\left( f,y_1,x_0\right)}{\left| x_1-x_0\right|}\rightarrow 0, \left( x_1\rightarrow x_0\right)\]
+\[\frac{r_2\left( f,y_1,x_0\right)}{\left| x_1-x_0\right|}\to 0, \left( x_1\to x_0\right)\]
 
 \begin{definition}{8.53}
 Die Matrix der Zweiten partiellen Ableitungen heisst die Hesse - Matrix von $f$, und mit $\Hess(f)$ oder $\nabla^2 f$ bezeichnet
 \begin{align*}
 \Hess(f)= & \nabla^2 f:=\left( \frac{\partial^2 f}{\partial x^i\cdot\partial x^j}\right)_{i,j=1\dots n}\\
- = & \left( {\begin{array}{*{20}{c}}{\frac{{{\partial ^2}f}}{{\partial x'\partial x'}}}&{\frac{{{\partial ^2}f}}{{\partial x'\partial {x^2}}}}& \ldots &{\frac{{{\partial ^2}f}}{{\partial x'\partial {x^n}}}}\\{\frac{{{\partial ^2}f}}{{\partial {x^2}\partial x'}}}&{\frac{{{\partial ^2}f}}{{\partial {x^2}\partial {x^2}}}}& \ldots &{\frac{{{\partial ^2}f}}{{\partial {x^2}\partial {x^n}}}}\\ \vdots & \vdots & \ddots & \vdots \\{\frac{{{\partial ^2}f}}{{\partial {x^n}\partial x'}}}& \ldots & \ldots &{\frac{{{\partial ^2}f}}{{\partial {x^n}\partial {x^n}}}}\end{array}} \right)
+ = & \left( {\begin{array}{*{20}{c}}
+{\frac{{{\partial ^2}f}}{{\partial x'\partial x'}}}&{\frac{{{\partial ^2}f}}{{\partial x'\partial {x^2}}}}& \ldots &{\frac{{{\partial ^2}f}}{{\partial x'\partial {x^n}}}}\\
+{\frac{{{\partial ^2}f}}{{\partial {x^2}\partial x'}}}&{\frac{{{\partial ^2}f}}{{\partial {x^2}\partial {x^2}}}}& \ldots &{\frac{{{\partial ^2}f}}{{\partial {x^2}\partial {x^n}}}}\\
+ \vdots & \vdots & \ddots & \vdots \\
+{\frac{{{\partial ^2}f}}{{\partial {x^n}\partial x'}}}& \ldots & \ldots &{\frac{{{\partial ^2}f}}{{\partial {x^n}\partial {x^n}}}}
+\end{array}} \right)
 \end{align*}
 \end{definition}
 Seien $\nabla f,x_1-x_0$ Zeilenvektoren und sei $\left( x-x_0\right)^t$ der zu $x_1-x_0$ transponierte Spaltenvektor . Dann wird die Taylorentwicklung von Grad 2 äquivalent zu 
@@ -1103,15 +1134,36 @@ $f\left( x,y\right)=e^{x+y}\cos x$ im Punkt $(0,0)$. Die Taylorentwicklung vom G
 \frac{{{\partial ^2}f}}{{\partial {x^2}}}(0,0) = & 0\\
 \frac{{{\partial ^2}f}}{{\partial {y^2}}} = & {e^{x + y}}\cos x\hspace{10mm}\frac{{{\partial ^2}f}}{{\partial {y^2}}}(0,0) = 1
 \end{align*}
-\[{\nabla ^2}f(0,0) = \left( {\begin{array}{*{20}{c}}0&1\\1&1\end{array}} \right)\]
+\[{\nabla ^2}f(0,0) = \left( {\begin{array}{*{20}{c}}
+0&1\\
+1&1
+\end{array}} \right)\]
 
 \begin{align*}
-\left( {\left( {x,y} \right) - \left( {0,0} \right)} \right){\nabla ^2}f\left( {0,0} \right){\left( {\left( {x,y} \right) - \left( {0,0} \right)} \right)^T} = & \left( {x,y} \right)\left( {\begin{array}{*{20}{c}}0&1\\1&1\end{array}} \right)\left( {\begin{array}{*{20}{c}}x\\y\end{array}} \right)\\
- = & \left( {x,y} \right)\left( {\begin{array}{*{20}{c}}y\\{x + y}\end{array}} \right)\\
+\left( {\left( {x,y} \right) - \left( {0,0} \right)} \right){\nabla ^2}f\left( {0,0} \right){\left( {\left( {x,y} \right) - \left( {0,0} \right)} \right)^T} = & \left( {x,y} \right)\left( {\begin{array}{*{20}{c}}
+0&1\\
+1&1
+\end{array}} \right)\left( {\begin{array}{*{20}{c}}
+x\\
+y
+\end{array}} \right)\\
+ = & \left( {x,y} \right)\left( {\begin{array}{*{20}{c}}
+y\\
+{x + y}
+\end{array}} \right)\\
  = &\text{ }2xy+y^2
 \end{align*}
 \begin{align*}
-f\left( {x,y} \right) = & \text{ }{e^{x + y}}\cos x = 1 + \left( {\begin{array}{*{20}{c}}1\\1\end{array}} \right)\left( {x,y} \right) + \frac{1}{2}\left( {x,y} \right)\left( {\begin{array}{*{20}{c}}0&1\\1&1\end{array}} \right)\left( {\begin{array}{*{20}{c}}x\\y\end{array}} \right)\\
+f\left( {x,y} \right) = & \text{ }{e^{x + y}}\cos x = 1 + \left( {\begin{array}{*{20}{c}}
+1\\
+1
+\end{array}} \right)\left( {x,y} \right) + \frac{1}{2}\left( {x,y} \right)\left( {\begin{array}{*{20}{c}}
+0&1\\
+1&1
+\end{array}} \right)\left( {\begin{array}{*{20}{c}}
+x\\
+y
+\end{array}} \right)\\
  = & \text{ } 1 + \left( {x,y} \right) + \frac{1}{2}\left( {2xy + {y^2}} \right) + {r_3}\left( {f,\left( {x,y} \right)} \right)
 \end{align*}
 Taylorpolynom von Grad 2: $1+\left( x+y\right)+\frac{1}{2}\left( 2xy+y^2\right)$\\
@@ -1132,7 +1184,10 @@ Im symmetrischen $2\times 2$ Fall ist die Gleichung auf Definitheit besonders le
 
 \subsubsection*{Satz 8.55}
 Eine Symmetrische Matrix 
-\[A = \left( {\begin{array}{*{20}{c}}{{a_{11}}}&{{a_{12}}}\\{{a_{12}}}&{{a_{11}}}\end{array}} \right)\]
+\[A = \left( {\begin{array}{*{20}{c}}
+{{a_{11}}}&{{a_{12}}}\\
+{{a_{12}}}&{{a_{11}}}
+\end{array}} \right)\]
 ist genau dann
 \begin{enumerate}
 \item Positive definit, wenn $\det A>0$ und $a_{11}>0$
@@ -1141,7 +1196,7 @@ ist genau dann
 \end{enumerate}
 
 \subsection*{Extrema von Funktionen mehrere Variablen}
-Jetzt werden wir nach Punkten $x\in\mathbb{R}^n$ sehen, in denen eine funktion $F:\mathbb{R}^n\rightarrow\mathbb{R}$ ein lokales Extremum annimmt. Wir erinnern uns an das Vorgehen im $f:\mathbb{R}\rightarrow\mathbb{R}$:
+Jetzt werden wir nach Punkten $x\in\mathbb{R}^n$ sehen, in denen eine funktion $F:\mathbb{R}^n\to\mathbb{R}$ ein lokales Extremum annimmt. Wir erinnern uns an das Vorgehen im $f:\mathbb{R}\to\mathbb{R}$:
 \begin{enumerate}
 \item Finde alle Punkte $x\in\mathbb{R}$, für die $f'(x)=0$ gilt (Notwendige Bedingung)
 \item Falls in einem solchen Punkt zusätzlich $f''(x)>0$ (bzw. $f''(z)<0$) gilt so handelt es sich um ein lokales Minimum (bzw. Maximum) (hinreichende Bedingung)
@@ -1155,7 +1210,7 @@ Ein Punkt $x_0\in\mathbb{R}^n$ mit $df\left( x_0\right)=0$ heisst \underline{kri
 \subsubsection*{Satz 8.56}
 Sei 
 \begin{align*}
-f: &\text{ } \Omega \subset\mathbb{R}^n\rightarrow\mathbb{R}\\
+f: &\text{ } \Omega \subset\mathbb{R}^n\to\mathbb{R}\\
 f \in & \text{ }C^2\left(\Omega\right); x_0\in\Omega
 \end{align*}
 \begin{enumerate}
@@ -1172,7 +1227,11 @@ f\left( x,y,z\right)= & \left(x-1\right)^2+\left(y+2\right)^2+\left(z+1\right)^2
 \nabla f= & \left( 2\left(x-1\right),2\left(y+2\right),2\left(z+1\right)\right)\\
 \nabla f\left( x_0\right)=&\left( 0,0,0\right)\Rightarrow x_0=\left( 1,-2,-1\right)
 \end{align*}
-\[{H_f}\left( {{x_0}} \right) = \left( {\begin{array}{*{20}{c}}2&0&0\\0&2&0\\0&0&2\end{array}} \right)\]
+\[{H_f}\left( {{x_0}} \right) = \left( {\begin{array}{*{20}{c}}
+2&0&0\\
+0&2&0\\
+0&0&2
+\end{array}} \right)\]
 $H_f\left( x_0\right)$ ist positiv definiert $\Rightarrow x_0\left( 1,-2,-1\right)$ ist ein lokales Minimum. 
 \item \begin{align*}
 f\left( x,y\right)= & \cos\left(x+2y\right)+\cos\left(2x+3y\right)\\
@@ -1182,24 +1241,36 @@ f\left( x,y\right)= & \cos\left(x+2y\right)+\cos\left(2x+3y\right)\\
 &-2\sin\left( x+2y\right)-3\sin\left( 2x+3y\right)=0
 \end{align*}
 \[\Rightarrow \sin\left( 2x+3y\right) = 0,\text{ }\sin\left( x+2y\right)=0\]
-\[ \Rightarrow \left. {\begin{array}{*{20}{r}}{2x + 3y = k\pi }\\{x + 2y = l\pi }\end{array}} \right\} \Rightarrow y = k\pi {\text{ und }}x = l\pi \]
+\[ \Rightarrow \left. {\begin{array}{*{20}{r}}
+{2x + 3y = k\pi }\\
+{x + 2y = l\pi }
+\end{array}} \right\} \Rightarrow y = k\pi {\text{ und }}x = l\pi \]
 Kritische punkte: $\left( \pi l,\pi k\right)\hspace{5mm}k,l\in\mathbb{Z}$
-\begin{align*}\frac{{\partial f}}{{\partial y\partial x}} =&\frac{{\partial f}}{{\partial x\partial y}} =  - 2\cos \left( {x + 2y} \right) - 6\cos \left( {2x + 3y} \right)\\\frac{{{\partial ^2}f}}{{\partial {x^2}}} =&- \cos \left( {x + 2y} \right) - 4\cos \left( {2x + 3y} \right)\\\frac{{{\partial ^2}f}}{{\partial {y^2}}} =&- 4\cos \left( {x + 2y} \right) - 9\cos \left( {2x + 3y} \right)
+\begin{align*}
+\frac{{\partial f}}{{\partial y\partial x}} =&\frac{{\partial f}}{{\partial x\partial y}} =  - 2\cos \left( {x + 2y} \right) - 6\cos \left( {2x + 3y} \right)\\
+\frac{{{\partial ^2}f}}{{\partial {x^2}}} =&- \cos \left( {x + 2y} \right) - 4\cos \left( {2x + 3y} \right)\\
+\frac{{{\partial ^2}f}}{{\partial {y^2}}} =&- 4\cos \left( {x + 2y} \right) - 9\cos \left( {2x + 3y} \right)
 \end{align*}
 \[\left( 0,0\right):\frac{{{\partial ^2}f}}{{\partial {x^2}}}=-5<0\]
-\[\left| {{\nabla ^2}f\left( {0,0} \right)} \right| = \left| {\begin{array}{*{20}{c}}{ - 5}&{ - 8}\\{ - 8}&{ - 13}\end{array}} \right| = 13 \cdot 5 - 64 = 1 < 0\]
+\[\left| {{\nabla ^2}f\left( {0,0} \right)} \right| = \left| {\begin{array}{*{20}{c}}
+{ - 5}&{ - 8}\\
+{ - 8}&{ - 13}
+\end{array}} \right| = 13 \cdot 5 - 64 = 1 < 0\]
 $\Rightarrow\nabla^2 f\left( 0,0\right)$ ist negative definiert und $\left( 0,0\right)$ ist eine lokale maximalestelle.\\
 
 Auch alle punkte $\left( -2\pi k,2\pi l\right)$ sind lokale maxima. Analog, bis auf Addition von Vielfachen von $2\pi$ $f$ hat lokale minimalestelle in $\left( \pi,\pi\right)$ und Sattelpunkte in $\left( 0,\pi\right)$ und $\left( \pi,0\right)$
 \end{enumerate}
 
 \section{Vektorwertige Funktionen}
-Sei $\Omega\in\mathbb{R}^n$, $f=\left( f^i\right)_{1 < i < l}\Omega\rightarrow\mathbb{R}^l$
+Sei $\Omega\in\mathbb{R}^n$, $f=\left( f^i\right)_{1 < i < l}\Omega\to\mathbb{R}^l$
 \begin{definition}{8.57}
 \begin{enumerate}
 \item Die Funktion \todo[inline]{can,t understand the function, page 203 top} heisst an der stelle $x_0\in\Omega$ differenzierbar, falls jede komponente $f^i$, $1 < i < l$ an der stelle $x_0$ differenzierbar ist.\\
 
-Das Differential $df\left( x_0\right)$ hat die Gestalt \[df\left( {{x_0}} \right) = \left( {\begin{array}{*{20}{c}}{df'\left( {{x_0}} \right)}\\{d{f^n}\left( {{x_0}} \right)}\end{array}} \right)\]
+Das Differential $df\left( x_0\right)$ hat die Gestalt \[df\left( {{x_0}} \right) = \left( {\begin{array}{*{20}{c}}
+{df'\left( {{x_0}} \right)}\\
+{d{f^n}\left( {{x_0}} \right)}
+\end{array}} \right)\]
 \item $f$ heisst auf $\Omega$ differenzierbar (bzw. von der Klasse $C^m$, $m\geq 1$) falls jedes $f^i$ differenzierbar ist (bzw. $f^i\in C^m\left( \Omega\right)$) $1\leq i \leq l$
 \end{enumerate}
 \end{definition}
@@ -1208,20 +1279,31 @@ Das Differential $df\left( x_0\right)$ hat die Gestalt \[df\left( {{x_0}} \right
 \item Bezüglich der Standardbasis $dx^j$, $1\leq j\leq n$ erhalten wir 
 \[d{f^i}\left( {{x_0}} \right) = \sum\limits_{j = 1}^n {\frac{{\partial {f^i}}}{{\partial {x^j}}}\left( {{x_0}} \right)d{x^j} = \left( {\frac{{\partial {f^i}}}{{\partial x'}}\left( {{x_0}} \right), \ldots ,\frac{{\partial {f^i}}}{{\partial {x^n}}}\left( {{x_0}} \right)} \right)} \]
 die Darstellung
-\[df\left( {{x_0}} \right) = \left( {\begin{array}{*{20}{c}}{\frac{{\partial f'}}{{\partial x'}}\left( {{x_0}} \right)}&{\frac{{\partial f'}}{{\partial {x^2}}}\left( {{x_0}} \right)}& \ldots &{\frac{{\partial f'}}{{\partial {x^n}}}\left( {{x_0}} \right)}\\{\frac{{\partial {f^2}}}{{\partial x'}}\left( {{x_0}} \right)}&{\frac{{\partial {f^2}}}{{\partial {x^2}}}\left( {{x_0}} \right)}& \ldots &{\frac{{\partial {f^2}}}{{\partial {x^n}}}\left( {{x_0}} \right)}\\ \vdots & \vdots & \ddots & \vdots \\{\frac{{\partial {f^l}}}{{\partial x'}}\left( {{x_0}} \right)}&{\frac{{\partial {f^l}}}{{\partial x'}}\left( {{x_0}} \right)}& \ldots &{\frac{{\partial {f^l}}}{{\partial {x^n}}}\left( {{x_0}} \right)}\end{array}} \right)\]
+\[df\left( {{x_0}} \right) = \left( {\begin{array}{*{20}{c}}
+{\frac{{\partial f'}}{{\partial x'}}\left( {{x_0}} \right)}&{\frac{{\partial f'}}{{\partial {x^2}}}\left( {{x_0}} \right)}& \ldots &{\frac{{\partial f'}}{{\partial {x^n}}}\left( {{x_0}} \right)}\\
+{\frac{{\partial {f^2}}}{{\partial x'}}\left( {{x_0}} \right)}&{\frac{{\partial {f^2}}}{{\partial {x^2}}}\left( {{x_0}} \right)}& \ldots &{\frac{{\partial {f^2}}}{{\partial {x^n}}}\left( {{x_0}} \right)}\\
+ \vdots & \vdots & \ddots & \vdots \\
+{\frac{{\partial {f^l}}}{{\partial x'}}\left( {{x_0}} \right)}&{\frac{{\partial {f^l}}}{{\partial x'}}\left( {{x_0}} \right)}& \ldots &{\frac{{\partial {f^l}}}{{\partial {x^n}}}\left( {{x_0}} \right)}
+\end{array}} \right)\]
 Die $l\times n$ matrix $df\left( x_0\right) = {\left( \frac{\partial f^i}{\partial x^j}\left( x_0\right)\right)}_{1\leq i\leq l, 1\leq j\leq n}$ heisst Jacobi oder Funktionalmatrix von $f$ an der Stelle $x_0$.
-\item Auch im Vektorwertigen Fall ist die Funktion $f$ genau dann differenzierbar in $x_0$, wenn eine lineare Abbildung $A:\mathbb{R}^n\rightarrow\mathbb{R}^l$ existiert mit 
+\item Auch im Vektorwertigen Fall ist die Funktion $f$ genau dann differenzierbar in $x_0$, wenn eine lineare Abbildung $A:\mathbb{R}^n\to\mathbb{R}^l$ existiert mit 
 \[\mathop {\lim }\limits_{x \to {x_0}} \frac{{f\left( x \right) - f\left( {{x_0}} \right) - A\left( {x - {x_0}} \right)}}{{\left| {x - {x_0}} \right|}} = 0\]
 \end{enumerate}
 
 \subsubsection*{Beispiel 8.59}
-\[f:\mathbb{R}^2\rightarrow\mathbb{R}\]
-\[f\left( {x,y} \right) = \left( {\begin{array}{*{20}{c}}{{x^2} - {y^2}}\\{2xy}\end{array}} \right)\]
-\[f\in C^\infty\left( \mathbb{R}^2\mathbb{R}^2\right) \text{ mit } df\left( {x,y} \right) = \left( {\begin{array}{*{20}{c}}{2x}&{ - 2y}\\{2y}&{2x}\end{array}} \right) \]\todo[inline]{Can't understant the symbol between the $\mathbb{R}^2$, page 205 middle to top}
+\[f:\mathbb{R}^2\to\mathbb{R}\]
+\[f\left( {x,y} \right) = \left( {\begin{array}{*{20}{c}}
+{{x^2} - {y^2}}\\
+{2xy}
+\end{array}} \right)\]
+\[f\in C^\infty\left( \mathbb{R}^2\mathbb{R}^2\right) \text{ mit } df\left( {x,y} \right) = \left( {\begin{array}{*{20}{c}}
+{2x}&{ - 2y}\\
+{2y}&{2x}
+\end{array}} \right) \]\todo[inline]{Can't understant the symbol between the $\mathbb{R}^2$, page 205 middle to top}
 Es gelten die üblichen Differentiationsregeln
 
 \subsubsection*{Satz 8.60}
-Sei $f,g:\Omega\subset\mathbb{R}^n\rightarrow\mathbb{R}^l$ an der Stelle $x_0\in\Omega$ differenzierbar und $\alpha\in\mathbb{R}$. dann sin die Funktionen $\alpha f$ und $f+g$ sowie das Skalarprodukt von $f$ und $g$ an der Stelle $x_0$ differenzierbar und 
+Sei $f,g:\Omega\subset\mathbb{R}^n\to\mathbb{R}^l$ an der Stelle $x_0\in\Omega$ differenzierbar und $\alpha\in\mathbb{R}$. dann sin die Funktionen $\alpha f$ und $f+g$ sowie das Skalarprodukt von $f$ und $g$ an der Stelle $x_0$ differenzierbar und 
 \begin{enumerate}
 \item $d\left( \alpha f\right) \left( x_0\right)=\alpha df\left( x_0\right)$ 
 \item $d\left( f+g\right) \left( x_0\right)=df\left( x_0\right) + dg\left( x_0\right)$
@@ -1229,27 +1311,52 @@ Sei $f,g:\Omega\subset\mathbb{R}^n\rightarrow\mathbb{R}^l$ an der Stelle $x_0\in
 wobei $f\left( x_0\right)\cdot dg\left( x_0\right)=\sum\limits_{i = 1}^l {{f^i}\left( {{x_0}} \right)d{g^i}\left( {{x_0}} \right)}$
 \end{enumerate}
 \subsubsection*{Satz 8.61}
-Seien $g:\Omega\rightarrow\mathbb{R}^l$ an der Stelle $x_0\in\Omega$ und $f:\mathbb{R}^l\rightarrow\mathbb{R}^m$ an der Stelle $g\left(x_0\right)$ differenzierbar.\\
+Seien $g:\Omega\to\mathbb{R}^l$ an der Stelle $x_0\in\Omega$ und $f:\mathbb{R}^l\to\mathbb{R}^m$ an der Stelle $g\left(x_0\right)$ differenzierbar.\\
 
-Dann ist die Funktion $f\circ g:\Omega\rightarrow\mathbb{R}^m$ an der Stelle $x_0$ differenzierbar, und 
+Dann ist die Funktion $f\circ g:\Omega\to\mathbb{R}^m$ an der Stelle $x_0$ differenzierbar, und 
 \[d\left( f\circ g\right)\left( x_0\right)=df\left( g\left( x_0\right)\right)\cdot dg\left( x_0\right)\]
 
 \subsubsection*{Beispiel}
 Sei
 \begin{align*}
-f:\mathbb{R}^2 & \rightarrow\mathbb{R}^2\\
-\left( x,y\right) & \rightarrow\left( {\begin{array}{*{20}{c}}{{x^2} - {y^2}}\\{2xy}\end{array}} \right) \hspace{20mm}df = \left( {\begin{array}{*{20}{c}}{2x}&{ - 2y}\\{2y}&{2x}\end{array}} \right)
+f:\mathbb{R}^2 & \to\mathbb{R}^2\\
+\left( x,y\right) & \to\left( {\begin{array}{*{20}{c}}
+{{x^2} - {y^2}}\\
+{2xy}
+\end{array}} \right) \hspace{20mm}df = \left( {\begin{array}{*{20}{c}}
+{2x}&{ - 2y}\\
+{2y}&{2x}
+\end{array}} \right)
 \end{align*} 
 \begin{align*}
-g:\mathbb{R}^3 & \rightarrow\mathbb{R}^3\\
-\left( x,y,z\right) & \rightarrow\left( {\begin{array}{*{20}{c}}{{x^2} +{y^2}+{z^2}}\\{xyz}\end{array}} \right) \hspace{15mm}dg = \left( {\begin{array}{*{20}{c}}{2x}&{2y}&{2z}\\{yz}&{xz}&{xy}\end{array}} \right)
+g:\mathbb{R}^3 & \to\mathbb{R}^3\\
+\left( x,y,z\right) & \to\left( {\begin{array}{*{20}{c}}
+{{x^2} +{y^2}+{z^2}}\\
+{xyz}
+\end{array}} \right) \hspace{15mm}dg = \left( {\begin{array}{*{20}{c}}
+{2x}&{2y}&{2z}\\
+{yz}&{xz}&{xy}
+\end{array}} \right)
 \end{align*} 
 \begin{align*}
-\left( f\circ g\right):\mathbb{R}^3 & \rightarrow\mathbb{R}^2\\
-\left(x,y,z\right)&\rightarrow \left( {\begin{array}{*{20}{c}}{{{\left( {{x^2} + {y^2} + {z^2}} \right)}^2} - {{\left( {xyz} \right)}^2}}\\{2\left( {{x^2} + {y^2} + {z^2}} \right)\left( {xyz} \right)}\end{array}} \right)
+\left( f\circ g\right):\mathbb{R}^3 & \to\mathbb{R}^2\\
+\left(x,y,z\right)&\to \left( {\begin{array}{*{20}{c}}
+{{{\left( {{x^2} + {y^2} + {z^2}} \right)}^2} - {{\left( {xyz} \right)}^2}}\\
+{2\left( {{x^2} + {y^2} + {z^2}} \right)\left( {xyz} \right)}
+\end{array}} \right)
 \end{align*}
 \begin{align*}
 d\left( {f \circ g} \right)\left( {x,y,z} \right)&= df\left( {g\left( {x,y,z} \right)} \right) \cdot dg\left( {x,y,z} \right)\\
-&= \left( {\begin{array}{*{20}{c}}{2\left( {{x^2} + {y^2} + {z^2}} \right)}&{ - 2xyz}\\{2xyz}&{2\left( {{x^2} + {y^2} + {z^2}} \right)}\end{array}} \right)\left( {\begin{array}{*{20}{c}}{2x}&{2y}&{2z}\\{yz}&{xz}&{xy}\end{array}} \right)\\
-&=\left( {\begin{array}{*{20}{c}}{4x\left( {{x^2} + {y^2} + {z^2}} \right) - 2x{y^2}{z^2}}& * & * \\ * & * & * \\ * & * & * \end{array}} \right)
+&= \left( {\begin{array}{*{20}{c}}
+{2\left( {{x^2} + {y^2} + {z^2}} \right)}&{ - 2xyz}\\
+{2xyz}&{2\left( {{x^2} + {y^2} + {z^2}} \right)}
+\end{array}} \right)\left( {\begin{array}{*{20}{c}}
+{2x}&{2y}&{2z}\\
+{yz}&{xz}&{xy}
+\end{array}} \right)\\
+&=\left( {\begin{array}{*{20}{c}}
+{4x\left( {{x^2} + {y^2} + {z^2}} \right) - 2x{y^2}{z^2}}& * & * \\
+ * & * & * \\
+ * & * & * 
+\end{array}} \right)
 \end{align*}

--- a/Tex/Chapters/Chapter_9.tex
+++ b/Tex/Chapters/Chapter_9.tex
@@ -6,7 +6,7 @@ Im Eindimensionalen hatten wir mit dem Integral \[\int\limits_a^b f(x)dx\] den F
 
 Konstruktionsprinzip für Bereichsintegrale ist Analog. Aber die Definitionsbereich $D$ ist komplizierter. Wir betrachten zunächst den Fall zweier Variabler, $n=2$, und einen Definitionsbereich $D\subset\mathbb{R}^2$ der Form
 \[D=\lbrack a_1,b_1\rbrack\times\lbrack a_2,b_2\rbrack\subset\mathbb{R}^2\]
-d.h. $D$ ist ein kompakter Quader (Rechteck). Sei $f:D\rightarrow\mathbb{R}$ eine beschränkte Funktion.
+d.h. $D$ ist ein kompakter Quader (Rechteck). Sei $f:D\to\mathbb{R}$ eine beschränkte Funktion.
 
 \begin{definition}{9.1}
 Mann nennt $Z=\left\{ \left( x_0,x_1,\dots,x_n\right), \left( y_0,y_1,\dots,y_m\right)\right\}$ eine Zerlegung des Quaders $D=\lbrack a_1,b_1\rbrack\times\lbrack a_2,b_2\rbrack$ falls gilt 
@@ -39,7 +39,7 @@ Für zwei beliebige Zerlegungen $Z_1,Z_2$ gilt stets \[U_f\left( Z_1\right)\leq 
 \missingfigure{Page 211 bottom}
 \end{enumerate}
 \begin{definition}{9.3}
-Sei $f:D\rightarrow\mathbb{R}$ beschränkt 
+Sei $f:D\to\mathbb{R}$ beschränkt 
 \begin{enumerate}
 \item Riemannsche Unterintegral bsz. Riemannsche Oberintegral der Funktion $f\left( x\right)$ über $D$ ist 
 \begin{align*}
@@ -60,7 +60,7 @@ oder
 
 \subsubsection*{Satz 9.4 (Elementare Eigenschaften des Integrals)}
 \begin{enumerate}
-\item \underline{Linearität:} Seien $f,g: D\rightarrow\mathbb{R}$ beschränkt und R integrabel, $\beta,\alpha\in\mathbb{R}$. Dann sind $\alpha f$, $f+g$ R - Integrabel
+\item \underline{Linearität:} Seien $f,g: D\to\mathbb{R}$ beschränkt und R integrabel, $\beta,\alpha\in\mathbb{R}$. Dann sind $\alpha f$, $f+g$ R - Integrabel
 \[\int\limits_D {\left( {\alpha f + \beta g} \right)d\mu  = \alpha \int\limits_D {fd\mu }  + \beta \int\limits_D {gd\mu } } \]
 \item \underline{Monotonie:} Gilt $f(x)\leq g(x)$, $\forall x\in D$, so folgt \[\int\limits_D {fd\mu }  \le \int\limits_D {gd\mu } \]
 \item\underline{Positivität:} Gilt für alle $x\in D$, $f(x)\geq 0$ (d.h. $f(x)$ ist nichtnegativ), so folgt \[\int\limits_D {fd\mu }  \ge 0\]
@@ -79,16 +79,30 @@ d.h. das Integral von $f$ über $Q$ kann iterativ durch $1-$Dimensionale Integra
 \subsubsection*{Beispiel 9.6}
 \begin{enumerate}
 \item Sei $f\left( x,y\right)=2x+2yx$, $Q=\lbrack 0,1\rbrack\times\lbrack -2,2\rbrack$
-\begin{align*}\int\limits_Q {fd\mu }  =&\int\limits_{ - 2}^2 {\left( {\int\limits_0^1 {\left( {2x + 2yx} \right)dx} } \right)dy} \\=&\int\limits_{ - 2}^2 {\left( {\left. {{x^2} + y{x^2}} \right|_0^1} \right)dy} \\=&\int\limits_{ - 2}^2 {\left( {1 + y} \right)dy}  = \left. {y + \frac{{{y^2}}}{2}} \right|_{ - 2}^2 = 4
+\begin{align*}
+\int\limits_Q {fd\mu }  =&\int\limits_{ - 2}^2 {\left( {\int\limits_0^1 {\left( {2x + 2yx} \right)dx} } \right)dy} \\
+=&\int\limits_{ - 2}^2 {\left( {\left. {{x^2} + y{x^2}} \right|_0^1} \right)dy} \\
+=&\int\limits_{ - 2}^2 {\left( {1 + y} \right)dy}  = \left. {y + \frac{{{y^2}}}{2}} \right|_{ - 2}^2 = 4
 \end{align*}
 \underline{Oder:}
-\begin{align*}&\int\limits_0^1 {\left( {\int\limits_{ - 2}^2 {\left( {2x + 2yx} \right)dy} } \right)dx} \\ =&\int\limits_0^1 {\left( {\left. {2xy + {y^2}x} \right|_{ - 2}^2} \right)dx} \\ =&\int\limits_0^1 {\left[ {\left( {4x + 4x} \right) - \left( { - 4x + 4x} \right)} \right]dx} \\ =&\int\limits_0^1 {8xdx}  = \left. {4{x^2}} \right|_0^1 = 4
+\begin{align*}
+&\int\limits_0^1 {\left( {\int\limits_{ - 2}^2 {\left( {2x + 2yx} \right)dy} } \right)dx} \\
+ =&\int\limits_0^1 {\left( {\left. {2xy + {y^2}x} \right|_{ - 2}^2} \right)dx} \\
+ =&\int\limits_0^1 {\left[ {\left( {4x + 4x} \right) - \left( { - 4x + 4x} \right)} \right]dx} \\
+ =&\int\limits_0^1 {8xdx}  = \left. {4{x^2}} \right|_0^1 = 4
 \end{align*}
-\item \begin{align*}&\int\limits_0^1 {\int\limits_0^{2\pi } {\left( {{e^x}\sin y} \right)dy} dx} \\=&\int\limits_0^1 {\left( {\left. { - {e^x}\cos y} \right|_0^{2\pi }} \right)dx} \\
-=&\int\limits_0^1 0 dx = 0\end{align*}
+\item \begin{align*}
+&\int\limits_0^1 {\int\limits_0^{2\pi } {\left( {{e^x}\sin y} \right)dy} dx} \\
+=&\int\limits_0^1 {\left( {\left. { - {e^x}\cos y} \right|_0^{2\pi }} \right)dx} \\
+=&\int\limits_0^1 0 dx = 0
+\end{align*}
 \underline{Oder:}
-\begin{align*}&\int\limits_0^{2\pi } {\left( {\int\limits_0^1 {{e^x}\sin ydx} } \right)dy} \\=&\int\limits_0^{2\pi } {\left( {\left. {\sin y{e^x}} \right|_0^1} \right)dy} \\=&\int\limits_0^{2\pi } {\left( {e - 1} \right)\sin ydy} \\
-=&\left. { - \left( {e - 1} \right)\cos y} \right|_0^{2\pi } = 0\end{align*}
+\begin{align*}
+&\int\limits_0^{2\pi } {\left( {\int\limits_0^1 {{e^x}\sin ydx} } \right)dy} \\
+=&\int\limits_0^{2\pi } {\left( {\left. {\sin y{e^x}} \right|_0^1} \right)dy} \\
+=&\int\limits_0^{2\pi } {\left( {e - 1} \right)\sin ydy} \\
+=&\left. { - \left( {e - 1} \right)\cos y} \right|_0^{2\pi } = 0
+\end{align*}
 \end{enumerate}
 
 \subsection*{Geometrische Dehnung}\todo{Not sure about the text size...}
@@ -136,9 +150,13 @@ so gilt
  =&\int\limits_0^1 {\left( {\left. {xy - \frac{{{y^2}}}{2}} \right|_0^{\sqrt {1 - {x^2}} }} \right)} dx\\
 =&\int\limits_0^1 {\left( {x\sqrt {1 - {x^2}}  - \frac{{1 - {x^2}}}{2}} \right)dx}\\
 =&\int\limits_0^1 {x\sqrt {1 - {x^2}} } dx - \frac{1}{2}\int\limits_0^1 {1 - {x^2}dx}\\
- =&\frac{1}{2} - \frac{2}{3} = \frac{1}{3}\end{align*}
+ =&\frac{1}{2} - \frac{2}{3} = \frac{1}{3}
+\end{align*}
 \begin{align*}
-&\int\limits_0^1 {x\sqrt {1 - {x^2}} dx} \begin{array}{*{20}{c}}{u = 1 - {x^2}}\\{du =  - 2xdx}\end{array}\\
+&\int\limits_0^1 {x\sqrt {1 - {x^2}} dx} \begin{array}{*{20}{c}}
+{u = 1 - {x^2}}\\
+{du =  - 2xdx}
+\end{array}\\
 &=  - \frac{1}{2}\int\limits_0^1 {\sqrt u du}  = \left. { - \frac{1}{2} \cdot \frac{2}{3}{u^{\frac{3}{2}}}} \right|_0^1 = \frac{1}{3}\\
 &\int\limits_D {fd\mu  = \frac{1}{3} - \frac{1}{3} = 0} 
 \end{align*}
@@ -160,7 +178,10 @@ Zu Berechnung des Doppelintegrals zerlegen wir das Gebiet in Streifen parallel z
 \end{align*}
 \item Sei $D:$
 \missingfigure{Page 224 top}
-\[\int\limits_D {fd\mu } \mathop  = \limits_{\begin{array}{*{20}{c}} \downarrow \\ * \end{array}} \int\limits_{ - 1}^1 {\left( {\int\limits_{x = {y^2}}^1 {fdx} } \right)} dy\]
+\[\int\limits_D {fd\mu } \mathop  = \limits_{\begin{array}{*{20}{c}}
+ \downarrow \\
+ * 
+\end{array}} \int\limits_{ - 1}^1 {\left( {\int\limits_{x = {y^2}}^1 {fdx} } \right)} dy\]
 $$\text{(\textasteriskcentered $=$ Zerlegung des Gebietes in Streifen parallel zur $x-$achse)}$$
 oder mit Zerlegung in streifen parallel zur $y-$Achse
 \[\int\limits_D {fd\mu }  = \int\limits_{x = 0}^1 {\left( {\int\limits_{y =  - \sqrt x }^{y = \sqrt x } {f\left( {x,y} \right)dy} } \right)} dx\]
@@ -200,7 +221,7 @@ Eine Teilmenge $D\subset\mathbb{R}^3$ heisst Normalbereich, falls es eine Darste
 \end{definition}
 
 \subsubsection*{Satz 9.15}
-Sei $D\subset\mathbb{R}^3$ ein Normalbereich mit Darstellung wie oben, und $f:D\rightarrow\mathbb{R}$ stetig. Dann gilt \[\int\limits_D {fd\mu }  = \int\limits_a^b {\int\limits_{g(x)}^{h(x)} {\int\limits_{\varphi \left( {x,y} \right)}^{\psi \left( {x,y} \right)} {f\left( {x,y,z} \right)dzdydx} } } \]
+Sei $D\subset\mathbb{R}^3$ ein Normalbereich mit Darstellung wie oben, und $f:D\to\mathbb{R}$ stetig. Dann gilt \[\int\limits_D {fd\mu }  = \int\limits_a^b {\int\limits_{g(x)}^{h(x)} {\int\limits_{\varphi \left( {x,y} \right)}^{\psi \left( {x,y} \right)} {f\left( {x,y,z} \right)dzdydx} } } \]
 \missingfigure{Page 228, middle}
 $z=\varphi \left( {x,y} \right)$ und $z=\psi \left( {x,y} \right)$ stellen die ``Grund'' und Deckelfläche von $D$ dar. \\
 


### PR DESCRIPTION
replaced all `\rightarrow` with `\to` (identical) for improved legibility of latex
replaced `\to` by `\mapsto` in function definitions.

A correct function definition looks like this:

``` tex
$f: X \to Y, x \mapsto y$
```
