### PR TITLE
Fixed a typo in definition 3.43

### DIFF
--- a/Tex/Chapters/Chapter_3.tex
+++ b/Tex/Chapters/Chapter_3.tex
@@ -983,7 +983,7 @@ Wir können deshalb herleiten, dass
 
 \begin{definition}{3.43}
 Die Reihe $\sum\limits_1^\infty  {{a_k}} $ konvergiert absolut, falls die Reihe $\sum\abs{a_k}$ konvergiert
-\[ \text{Konv. }\Rightarrow\text{ abs. konv.}\]
+\[ \text{Konv. }\not\Rightarrow\text{ abs. konv.}\]
 \end{definition}
 
 \todo[inline]{Is this sentence really needed? ``Warum sind absolut konvergent Reihen gut?'', page 113 middle}


### PR DESCRIPTION
Hey again Lucas
I found another one. Convergence does in fact not imply absolute convergence.
In the handwitten notes it's correct, Analysis-INFK-week7 Page 13/25 of the Document or Page 113 in the Professors count.
I hope I didn't create any chaos when pulling from upstream (your Repo), merging locally and then pushing back to my repo on Github. If I did please let me know.
Have a nice day.
Joel
